### PR TITLE
Refactor ServerPool to use StringArrayHashMapUnmanaged

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1091,7 +1091,7 @@ pub const Connection = struct {
                 self.flusher_stop = false;
                 self.flusher_signaled = false;
                 self.mutex.unlock();
-                
+
                 self.flusher_thread = std.Thread.spawn(.{}, flusherLoop, .{self}) catch |err| {
                     log.err("Failed to restart flusher thread: {}", .{err});
                     self.triggerReconnect(err);


### PR DESCRIPTION
## Summary
- Refactor ServerPool from separate ArrayList + StringHashMap to unified StringArrayHashMapUnmanaged
- Add key field to Server struct for efficient lookups
- Simplify and optimize server selection algorithm

## Changes
- **Server struct**: Added `key` field to store host:port string, updated init/deinit accordingly
- **ServerPool struct**: Replaced `ArrayList(*Server)` + `StringHashMap(void)` with `StringArrayHashMapUnmanaged(*Server)`
- **getNextServer()**: Simplified using stored keys with `fetchSwapRemove`/`putAssumeCapacity`
- **Removed getCurrentServer()**: No longer needed with direct key-based lookups
- **Added getFirstServer()**: Helper method for cleaner code
- **Fixed shuffle()**: Updated to work with ArrayHashMap using `entries.swap()` + `reIndex()`

## Benefits
- **Reduced memory usage**: Single data structure instead of two
- **Better performance**: O(1) key-based operations, eliminated server pointer iteration
- **Cleaner API**: More intuitive methods, less complex internal state management
- **Maintained compatibility**: All existing tests pass unchanged

## Testing
- All existing unit tests pass
- Added verification for new ArrayHashMap behavior
- No breaking changes to public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined server management with host:port deduplication to prevent duplicate entries.
  - Improved server rotation and shuffling for more consistent load distribution.
  - Servers exceeding reconnect limits are automatically removed, enhancing failover behavior.
  - More accurate server count reporting in pool operations.

- Bug Fixes
  - Resolved issues where duplicate server URLs could lead to inconsistent selection and reconnection behavior.

- Style
  - Minor whitespace cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->