### PR TITLE
Add name/lang/version to CONNECT info

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,13 +28,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // Add version and name information from build.zig.zon (parsed at build time)
+    // Add version information from build.zig.zon (parsed at build time)
     const build_options = b.addOptions();
     const build_zon_content = @embedFile("build.zig.zon");
     
-    // Define structure matching our build.zig.zon
+    // Define structure to extract only version from build.zig.zon
     const BuildZigZon = struct {
-        name: enum { nats_zig },
         version: []const u8,
     };
     
@@ -48,21 +47,16 @@ pub fn build(b: *std.Build) void {
         .ignore_unknown_fields = true,
     }) catch |err| {
         std.debug.print("Failed to parse build.zig.zon: {}\n", .{err});
-        // Fallback values
+        // Fallback version
         build_options.addOption([]const u8, "client_version", "0.0.0");
-        build_options.addOption([]const u8, "client_name", "nats.zig");
         lib_mod.addOptions("build_options", build_options);
         return;
     };
     defer std.zon.parse.free(allocator, parsed);
     
     const client_version = parsed.version;
-    const client_name = switch (parsed.name) {
-        .nats_zig => "nats.zig",
-    };
     
     build_options.addOption([]const u8, "client_version", client_version);
-    build_options.addOption([]const u8, "client_name", client_name);
     lib_mod.addOptions("build_options", build_options);
 
     // Now, we will create a static library based on the module we created above.

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -665,7 +665,7 @@ pub const Connection = struct {
 
         // Send CONNECT + PING (enable headers support and include client info)
         const client_version = build_options.client_version;
-        const client_name = self.options.name orelse build_options.client_name;
+        const client_name = self.options.name orelse "nats.zig";
         
         var connect_buffer = ArrayList(u8).init(self.allocator);
         defer connect_buffer.deinit();


### PR DESCRIPTION
Implements issue #16 by adding required client information fields to the NATS CONNECT message.

## Changes
- Added version extraction from build.zig.zon in build system
- Updated CONNECT message to include:
  - `name`: Uses options.name or defaults to 'nats.zig'
  - `lang`: Set to 'zig'
  - `version`: Extracted from build.zig.zon
- Follows NATS protocol specification requirements
- All tests passing

Fixes #16

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connection handshake now includes client metadata (name, language, version).
  - Client name and version are embedded at build time and used by default; name falls back to “nats.zig” when unspecified.

- **Refactor**
  - Handshake payload is assembled dynamically (build-time options drive client metadata), improving robustness of CONNECT data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->