### PR TITLE
Fix subscription reference counting to prevent use-after-free crashes

### DIFF
--- a/src/ref_counter.zig
+++ b/src/ref_counter.zig
@@ -47,6 +47,7 @@ pub fn RefCounter(comptime T: type) type {
         /// are visible before the count reaches zero.
         pub fn decr(self: *Self) bool {
             const prev_ref_count = self.refs.fetchSub(1, .release);
+            std.debug.assert(prev_ref_count > 0);
             if (prev_ref_count == 1) {
                 // Use acquire load as substitute for fence (Zig 0.14 doesn't have @fence)
                 // This synchronizes with all release operations from other threads


### PR DESCRIPTION
## Summary

Fixes a critical use-after-free bug in subscription lifecycle management that was causing crashes during JetStream fetch operations and other concurrent scenarios.

## Root Cause

The connection's subscription map was storing subscription references without properly taking ownership via reference counting. This meant:
- Subscriptions started with ref_count = 1 (user ownership)
- Connection added them to map but didn't increment ref_count 
- When users called `deinit()`, ref_count went 1→0 and subscription was freed
- Map still contained dangling pointers to freed memory
- Server responses caused crashes when trying to access freed subscriptions

## Changes

- **Add `retain()` calls** when putting subscriptions in connection map
- **Add `release()` calls** when removing subscriptions from connection map
- **Fix connection cleanup** to release all subscription references before shutdown

## Impact

- **Eliminates use-after-free crashes** in fetch operations and async scenarios
- **Enables proper timeout handling** - fetch() now correctly times out and returns empty batches
- **Maintains backward compatibility** - no API changes, pure bug fix
- **Ensures proper shared ownership** between user code and connection internals

## Testing

All existing tests pass. The fix resolves panics that were occurring during JetStream pull subscription operations, particularly when timeouts occurred or when subscriptions were cleaned up while server responses were still being processed.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents rare crashes and resource leaks during subscribe/unsubscribe operations.
  * Ensures reliable cleanup of subscriptions when closing connections.

* **Refactor**
  * Updated subscription lifecycle management to use explicit retain/release, improving stability under heavy usage.
  * Added a debug-time safety check to guard against invalid reference count decrements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->