### PR TITLE
Add JetStream message operations

### DIFF
--- a/src/message.zig
+++ b/src/message.zig
@@ -31,6 +31,7 @@ pub const Message = struct {
 
     // Metadata
     sid: u64 = 0,
+    seq: u64 = 0, // TODO this doesn't really belong here
 
     // Headers
     headers: std.hash_map.StringHashMapUnmanaged(ArrayListUnmanaged([]const u8)) = .{},

--- a/src/message.zig
+++ b/src/message.zig
@@ -97,6 +97,30 @@ pub const Message = struct {
         return msg;
     }
 
+    // Create empty message with just arena allocation
+    pub fn initEmpty(allocator: Allocator) !*Self {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const arena_allocator = arena.allocator();
+        const msg = try arena_allocator.create(Self);
+
+        msg.* = .{
+            .subject = &[_]u8{},
+            .reply = null,
+            .data = &[_]u8{},
+            .headers = .{},
+            .raw_headers = null,
+            .needs_header_parsing = false,
+            .sid = 0,
+            .seq = 0,
+            .time = 0,
+            .arena = arena,
+        };
+
+        return msg;
+    }
+
     pub fn deinit(self: *Self) void {
         // Arena takes care of ALL allocations including the message struct itself!
         self.arena.deinit();

--- a/src/message.zig
+++ b/src/message.zig
@@ -108,14 +108,7 @@ pub const Message = struct {
 
         msg.* = .{
             .subject = &[_]u8{},
-            .reply = null,
             .data = &[_]u8{},
-            .headers = .{},
-            .raw_headers = null,
-            .needs_header_parsing = false,
-            .sid = 0,
-            .seq = 0,
-            .time = 0,
             .arena = arena,
         };
 

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -15,6 +15,7 @@ pub const jetstream_nak_tests = @import("jetstream_nak_test.zig");
 pub const jetstream_sync_tests = @import("jetstream_sync_test.zig");
 pub const jetstream_stream_purge_tests = @import("jetstream_stream_purge_test.zig");
 pub const jetstream_pull_tests = @import("jetstream_pull_test.zig");
+pub const jetstream_msg_tests = @import("jetstream_msg_test.zig");
 
 const utils = @import("utils.zig");
 

--- a/tests/jetstream_msg_test.zig
+++ b/tests/jetstream_msg_test.zig
@@ -1,0 +1,245 @@
+const std = @import("std");
+const testing = std.testing;
+const nats = @import("nats");
+const utils = @import("utils.zig");
+
+test "get message by sequence" {
+    const conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+    defer js.deinit();
+
+    // Create stream
+    const stream_config = nats.StreamConfig{
+        .name = "TEST_MSG_GET",
+        .subjects = &.{"test.msg.get"},
+    };
+    var stream_info = try js.addStream(stream_config);
+    defer stream_info.deinit();
+
+    // Publish test messages
+    try conn.publish("test.msg.get", "First message");
+    try conn.publish("test.msg.get", "Second message");
+    try conn.publish("test.msg.get", "Third message");
+    try conn.flush();
+
+    // Get message by sequence
+    const msg = try js.getMsg("TEST_MSG_GET", 1);
+    defer msg.deinit();
+
+    try testing.expectEqualStrings("test.msg.get", msg.subject);
+    try testing.expectEqualStrings("First message", msg.data);
+    try testing.expectEqual(@as(u64, 1), msg.seq);
+
+    // Get second message
+    const msg2 = try js.getMsg("TEST_MSG_GET", 2);
+    defer msg2.deinit();
+    
+    try testing.expectEqualStrings("Second message", msg2.data);
+    try testing.expectEqual(@as(u64, 2), msg2.seq);
+}
+
+test "get last message by subject" {
+    const conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+    defer js.deinit();
+
+    // Create stream
+    const stream_config = nats.StreamConfig{
+        .name = "TEST_MSG_LAST",
+        .subjects = &.{"test.last.*"},
+    };
+    var stream_info = try js.addStream(stream_config);
+    defer stream_info.deinit();
+
+    // Publish messages to different subjects
+    try conn.publish("test.last.foo", "First foo");
+    try conn.publish("test.last.bar", "First bar");
+    try conn.publish("test.last.foo", "Second foo");
+    try conn.publish("test.last.bar", "Second bar");
+    try conn.publish("test.last.foo", "Third foo"); // This should be the last for foo
+    try conn.flush();
+
+    // Get last message by subject
+    const last_foo = try js.getLastMsg("TEST_MSG_LAST", "test.last.foo");
+    defer last_foo.deinit();
+
+    try testing.expectEqualStrings("test.last.foo", last_foo.subject);
+    try testing.expectEqualStrings("Third foo", last_foo.data);
+    try testing.expectEqual(@as(u64, 5), last_foo.seq);
+
+    const last_bar = try js.getLastMsg("TEST_MSG_LAST", "test.last.bar");
+    defer last_bar.deinit();
+
+    try testing.expectEqualStrings("test.last.bar", last_bar.subject);
+    try testing.expectEqualStrings("Second bar", last_bar.data);
+    try testing.expectEqual(@as(u64, 4), last_bar.seq);
+}
+
+test "delete message" {
+    const conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+    defer js.deinit();
+
+    // Create stream
+    const stream_config = nats.StreamConfig{
+        .name = "TEST_MSG_DELETE",
+        .subjects = &.{"test.msg.delete"},
+    };
+    var stream_info = try js.addStream(stream_config);
+    defer stream_info.deinit();
+
+    // Publish test messages
+    try conn.publish("test.msg.delete", "Message 1");
+    try conn.publish("test.msg.delete", "Message 2");
+    try conn.publish("test.msg.delete", "Message 3");
+    try conn.flush();
+
+    // Verify message exists before deletion
+    const msg2_before = try js.getMsg("TEST_MSG_DELETE", 2);
+    defer msg2_before.deinit();
+    try testing.expectEqualStrings("Message 2", msg2_before.data);
+
+    // Delete message 2
+    const deleted = try js.deleteMsg("TEST_MSG_DELETE", 2);
+    try testing.expect(deleted);
+
+    // Verify other messages still exist
+    const msg1_after = try js.getMsg("TEST_MSG_DELETE", 1);
+    defer msg1_after.deinit();
+    try testing.expectEqualStrings("Message 1", msg1_after.data);
+
+    const msg3_after = try js.getMsg("TEST_MSG_DELETE", 3);
+    defer msg3_after.deinit();
+    try testing.expectEqualStrings("Message 3", msg3_after.data);
+
+    // Attempting to get deleted message should fail
+    const get_deleted_result = js.getMsg("TEST_MSG_DELETE", 2);
+    try testing.expectError(error.JetStreamError, get_deleted_result);
+}
+
+test "erase message" {
+    const conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+    defer js.deinit();
+
+    // Create stream
+    const stream_config = nats.StreamConfig{
+        .name = "TEST_MSG_ERASE",
+        .subjects = &.{"test.msg.erase"},
+    };
+    var stream_info = try js.addStream(stream_config);
+    defer stream_info.deinit();
+
+    // Publish test messages
+    try conn.publish("test.msg.erase", "Message 1");
+    try conn.publish("test.msg.erase", "Message 2");
+    try conn.publish("test.msg.erase", "Message 3");
+    try conn.flush();
+
+    // Verify message exists before erasure
+    const msg2_before = try js.getMsg("TEST_MSG_ERASE", 2);
+    defer msg2_before.deinit();
+    try testing.expectEqualStrings("Message 2", msg2_before.data);
+
+    // Erase message 2 (securely remove from storage)
+    const erased = try js.eraseMsg("TEST_MSG_ERASE", 2);
+    try testing.expect(erased);
+
+    // Verify other messages still exist
+    const msg1_after = try js.getMsg("TEST_MSG_ERASE", 1);
+    defer msg1_after.deinit();
+    try testing.expectEqualStrings("Message 1", msg1_after.data);
+
+    const msg3_after = try js.getMsg("TEST_MSG_ERASE", 3);
+    defer msg3_after.deinit();
+    try testing.expectEqualStrings("Message 3", msg3_after.data);
+
+    // Attempting to get erased message should fail
+    const get_erased_result = js.getMsg("TEST_MSG_ERASE", 2);
+    try testing.expectError(error.JetStreamError, get_erased_result);
+}
+
+test "get message with headers" {
+    const conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+    defer js.deinit();
+
+    // Create stream
+    const stream_config = nats.StreamConfig{
+        .name = "TEST_MSG_HEADERS",
+        .subjects = &.{"test.msg.headers"},
+    };
+    var stream_info = try js.addStream(stream_config);
+    defer stream_info.deinit();
+
+    // Create message with headers
+    var msg = try nats.Message.init(std.testing.allocator, "test.msg.headers", null, "Message with headers");
+    defer msg.deinit();
+    
+    try msg.headerSet("X-Test-Header", "test-value");
+    try msg.headerSet("X-Another-Header", "another-value");
+
+    // Publish message with headers
+    try conn.publishMsg(msg);
+    try conn.flush();
+
+    // Get the message back
+    const retrieved = try js.getMsg("TEST_MSG_HEADERS", 1);
+    defer retrieved.deinit();
+
+    // Verify message properties
+    try testing.expectEqualStrings("test.msg.headers", retrieved.subject);
+    try testing.expectEqualStrings("Message with headers", retrieved.data);
+    try testing.expectEqual(@as(u64, 1), retrieved.seq);
+
+    // Verify headers are preserved
+    const test_header = try retrieved.headerGet("X-Test-Header");
+    try testing.expect(test_header != null);
+    try testing.expectEqualStrings("test-value", test_header.?);
+
+    const another_header = try retrieved.headerGet("X-Another-Header");
+    try testing.expect(another_header != null);
+    try testing.expectEqualStrings("another-value", another_header.?);
+}
+
+test "message operations error cases" {
+    const conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+    defer js.deinit();
+
+    // Test with non-existent stream
+    const get_nonexistent_stream = js.getMsg("NON_EXISTENT_STREAM", 1);
+    try testing.expectError(error.JetStreamError, get_nonexistent_stream);
+
+    // Create stream for other error tests
+    const stream_config = nats.StreamConfig{
+        .name = "TEST_MSG_ERRORS",
+        .subjects = &.{"test.msg.errors"},
+    };
+    var stream_info = try js.addStream(stream_config);
+    defer stream_info.deinit();
+
+    // Test getting non-existent message by sequence
+    const get_nonexistent_msg = js.getMsg("TEST_MSG_ERRORS", 999);
+    try testing.expectError(error.JetStreamError, get_nonexistent_msg);
+
+    // Test getting non-existent message by subject
+    const get_nonexistent_subject = js.getLastMsg("TEST_MSG_ERRORS", "non.existent.subject");
+    try testing.expectError(error.JetStreamError, get_nonexistent_subject);
+
+    // Test deleting non-existent message
+    const delete_result = js.deleteMsg("TEST_MSG_ERRORS", 999);
+    try testing.expectError(error.JetStreamError, delete_result);
+}


### PR DESCRIPTION
This PR adds JetStream message operations functionality:

## Changes
- Add `getMsg()` and `getLastMsg()` methods to retrieve messages from streams
- Add `deleteMsg()` and `eraseMsg()` methods to remove messages from streams  
- Add `initEmpty()` method to Message for creating empty messages
- Add new test file for message operations
- Support getting messages by sequence number or last message by subject
- Support secure deletion (erase) vs regular deletion
- Handle base64 decoding of message data and headers

## API Changes
- `JetStream.getMsg(stream_name, seq)` - Get message by sequence number
- `JetStream.getLastMsg(stream_name, subject)` - Get last message by subject
- `JetStream.deleteMsg(stream_name, seq)` - Delete message (mark as deleted)
- `JetStream.eraseMsg(stream_name, seq)` - Erase message (secure removal)
- `Message.initEmpty(allocator)` - Create empty message with arena

## Testing
- Added comprehensive test file for message operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JetStream message operations: get by sequence, get-last-by-subject, delete, and erase messages.
  - Pull-based consumption with inbox-backed pull subscriptions and batch fetch.
  - Convenience constructor to create empty messages.

- Improvements
  - Better handling of idle heartbeats and flow-control during pulls.
  - Safer resource and lifecycle management for messages and subscriptions.

- Tests
  - New comprehensive tests covering message ops, headers, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->