### PR TITLE
Make message callbacks fallible

### DIFF
--- a/src/dispatcher.zig
+++ b/src/dispatcher.zig
@@ -124,7 +124,10 @@ pub const Dispatcher = struct {
 
         // Call the subscription's handler in this dispatcher thread context
         if (subscription.handler) |handler| {
-            handler.call(message);
+            handler.call(message) catch |err| {
+                log.err("Message handler failed for subscription {}: {}", .{ subscription.sid, err });
+                // For now, just continue - message will be cleaned up
+            };
         } else {
             // No handler - this shouldn't happen for async subscriptions
             log.warn("Received message for subscription {} without handler", .{subscription.sid});

--- a/src/dispatcher.zig
+++ b/src/dispatcher.zig
@@ -123,15 +123,16 @@ pub const Dispatcher = struct {
         const message = dispatch_msg.message;
 
         // Call the subscription's handler in this dispatcher thread context
+        // Message ownership is transferred to the handler - handler is responsible for cleanup
         if (subscription.handler) |handler| {
             handler.call(message) catch |err| {
                 log.err("Message handler failed for subscription {}: {}", .{ subscription.sid, err });
-                // For now, just continue - message will be cleaned up
+                // Handler owns the message even on error - no cleanup here
             };
         } else {
             // No handler - this shouldn't happen for async subscriptions
             log.warn("Received message for subscription {} without handler", .{subscription.sid});
-            message.deinit(); // Clean up orphaned message
+            message.deinit(); // Clean up orphaned message (no handler to transfer ownership to)
         }
     }
 };

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -902,7 +902,7 @@ pub const JetStream = struct {
 
         // Define the handler inline to avoid the two-level context issue
         const JSHandler = struct {
-            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) void {
+            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) subscription_mod.MsgHandlerError!void {
                 // Check for status messages (heartbeats and flow control)
                 if (msg.headers.get("Status")) |status_values| {
                     if (status_values.items.len > 0) {

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -902,7 +902,7 @@ pub const JetStream = struct {
 
         // Define the handler inline to avoid the two-level context issue
         const JSHandler = struct {
-            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) subscription_mod.MsgHandlerError!void {
+            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) anyerror!void {
                 // Check for status messages (heartbeats and flow control)
                 if (msg.headers.get("Status")) |status_values| {
                     if (status_values.items.len > 0) {

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -902,7 +902,7 @@ pub const JetStream = struct {
 
         // Define the handler inline to avoid the two-level context issue
         const JSHandler = struct {
-            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) anyerror!void {
+            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) subscription_mod.MsgHandlerError!void {
                 // Check for status messages (heartbeats and flow control)
                 if (msg.headers.get("Status")) |status_values| {
                     if (status_values.items.len > 0) {

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -902,7 +902,7 @@ pub const JetStream = struct {
 
         // Define the handler inline to avoid the two-level context issue
         const JSHandler = struct {
-            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) subscription_mod.MsgHandlerError!void {
+            fn wrappedHandler(msg: *Message, js: *JetStream, user_args: @TypeOf(args)) anyerror!void {
                 // Check for status messages (heartbeats and flow control)
                 if (msg.headers.get("Status")) |status_values| {
                     if (status_values.items.len > 0) {
@@ -923,10 +923,15 @@ pub const JetStream = struct {
                     msg.deinit(); // Clean up on error
                     return;
                 };
-                // No need for manual cleanup - the arena handles everything
 
-                // Call user handler with JetStream message
-                @call(.auto, handlerFn, .{js_msg} ++ user_args);
+                // Call user handler with JetStream message - handler owns cleanup responsibility
+                // Support both void and fallible handlers  
+                const ReturnType = @typeInfo(@TypeOf(handlerFn)).@"fn".return_type.?;
+                if (ReturnType == void) {
+                    @call(.auto, handlerFn, .{js_msg} ++ user_args);
+                } else {
+                    try @call(.auto, handlerFn, .{js_msg} ++ user_args);
+                }
             }
         };
 

--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -16,6 +16,7 @@ const Allocator = std.mem.Allocator;
 const Message = @import("message.zig").Message;
 const Subscription = @import("subscription.zig").Subscription;
 const MsgHandler = @import("subscription.zig").MsgHandler;
+const MsgHandlerError = @import("subscription.zig").MsgHandlerError;
 const inbox = @import("inbox.zig");
 const nuid = @import("nuid.zig");
 const Connection = @import("connection.zig").Connection;
@@ -187,12 +188,12 @@ pub const ResponseManager = struct {
         }
     }
 
-    fn responseHandlerWrapper(msg: *Message, manager: *ResponseManager) anyerror!void {
+    fn responseHandlerWrapper(msg: *Message, manager: *ResponseManager) MsgHandlerError!void {
         // Regular subscribe handler wrapper
         try manager.responseHandler(msg);
     }
 
-    fn responseHandler(self: *ResponseManager, msg: *Message) anyerror!void {
+    fn responseHandler(self: *ResponseManager, msg: *Message) MsgHandlerError!void {
         var own_msg = true;
         defer if (own_msg) msg.deinit();
 

--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -16,6 +16,7 @@ const Allocator = std.mem.Allocator;
 const Message = @import("message.zig").Message;
 const Subscription = @import("subscription.zig").Subscription;
 const MsgHandler = @import("subscription.zig").MsgHandler;
+const MsgHandlerError = @import("subscription.zig").MsgHandlerError;
 const inbox = @import("inbox.zig");
 const nuid = @import("nuid.zig");
 const Connection = @import("connection.zig").Connection;
@@ -187,12 +188,12 @@ pub const ResponseManager = struct {
         }
     }
 
-    fn responseHandlerWrapper(msg: *Message, manager: *ResponseManager) void {
+    fn responseHandlerWrapper(msg: *Message, manager: *ResponseManager) MsgHandlerError!void {
         // Regular subscribe handler wrapper
-        manager.responseHandler(msg);
+        try manager.responseHandler(msg);
     }
 
-    fn responseHandler(self: *ResponseManager, msg: *Message) void {
+    fn responseHandler(self: *ResponseManager, msg: *Message) MsgHandlerError!void {
         var own_msg = true;
         defer if (own_msg) msg.deinit();
 

--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -16,7 +16,6 @@ const Allocator = std.mem.Allocator;
 const Message = @import("message.zig").Message;
 const Subscription = @import("subscription.zig").Subscription;
 const MsgHandler = @import("subscription.zig").MsgHandler;
-const MsgHandlerError = @import("subscription.zig").MsgHandlerError;
 const inbox = @import("inbox.zig");
 const nuid = @import("nuid.zig");
 const Connection = @import("connection.zig").Connection;
@@ -188,12 +187,12 @@ pub const ResponseManager = struct {
         }
     }
 
-    fn responseHandlerWrapper(msg: *Message, manager: *ResponseManager) MsgHandlerError!void {
+    fn responseHandlerWrapper(msg: *Message, manager: *ResponseManager) anyerror!void {
         // Regular subscribe handler wrapper
         try manager.responseHandler(msg);
     }
 
-    fn responseHandler(self: *ResponseManager, msg: *Message) MsgHandlerError!void {
+    fn responseHandler(self: *ResponseManager, msg: *Message) anyerror!void {
         var own_msg = true;
         defer if (own_msg) msg.deinit();
 

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -33,10 +33,10 @@ pub const MsgHandlerError = error{
 // Message handler storage for type-erased callback
 pub const MsgHandler = struct {
     ptr: *anyopaque,
-    callFn: *const fn (ptr: *anyopaque, msg: *Message) MsgHandlerError!void,
+    callFn: *const fn (ptr: *anyopaque, msg: *Message) anyerror!void,
     cleanupFn: *const fn (ptr: *anyopaque, allocator: Allocator) void,
 
-    pub fn call(self: *const MsgHandler, msg: *Message) MsgHandlerError!void {
+    pub fn call(self: *const MsgHandler, msg: *Message) anyerror!void {
         return self.callFn(self.ptr, msg);
     }
 
@@ -127,7 +127,7 @@ pub fn createMsgHandler(allocator: Allocator, comptime handlerFn: anytype, args:
     const Context = struct {
         args: @TypeOf(args),
 
-        pub fn call(ctx: *anyopaque, msg: *Message) MsgHandlerError!void {
+        pub fn call(ctx: *anyopaque, msg: *Message) anyerror!void {
             const self_ctx: *@This() = @ptrCast(@alignCast(ctx));
             
             // Handle both fallible and non-fallible user handler functions

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -22,12 +22,20 @@ const log = std.log.scoped(.subscription);
 
 
 // Message handler storage for type-erased callback
+// Error set for message handlers
+pub const MsgHandlerError = error{
+    /// Handler encountered an error processing the message
+    HandlerError,
+    /// Memory allocation error during message processing
+    OutOfMemory,
+};
+
 pub const MsgHandler = struct {
     ptr: *anyopaque,
-    callFn: *const fn (ptr: *anyopaque, msg: *Message) anyerror!void,
+    callFn: *const fn (ptr: *anyopaque, msg: *Message) MsgHandlerError!void,
     cleanupFn: *const fn (ptr: *anyopaque, allocator: Allocator) void,
 
-    pub fn call(self: *const MsgHandler, msg: *Message) anyerror!void {
+    pub fn call(self: *const MsgHandler, msg: *Message) MsgHandlerError!void {
         return self.callFn(self.ptr, msg);
     }
 
@@ -118,7 +126,7 @@ pub fn createMsgHandler(allocator: Allocator, comptime handlerFn: anytype, args:
     const Context = struct {
         args: @TypeOf(args),
 
-        pub fn call(ctx: *anyopaque, msg: *Message) anyerror!void {
+        pub fn call(ctx: *anyopaque, msg: *Message) MsgHandlerError!void {
             const self_ctx: *@This() = @ptrCast(@alignCast(ctx));
             
             // Handle both fallible and non-fallible user handler functions

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -20,15 +20,6 @@ const Dispatcher = @import("dispatcher.zig").Dispatcher;
 
 const log = std.log.scoped(.subscription);
 
-// Error set for message handlers
-pub const MsgHandlerError = error{
-    /// Handler encountered an error processing the message
-    HandlerError,
-    /// Memory allocation error during message processing
-    OutOfMemory,
-    /// Any other error that might occur during message handling
-    Unexpected,
-};
 
 // Message handler storage for type-erased callback
 pub const MsgHandler = struct {


### PR DESCRIPTION
Implements Phase 1 of making message callbacks fallible as requested in issue #39.

## Changes
- Add explicit `MsgHandlerError` error set for callback failures
- Update `MsgHandler` interface to be fallible
- Add error logging in dispatcher thread
- Maintain backward compatibility with void-returning handlers
- Update internal handlers (ResponseManager, JetStream)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handlers (including push/response handlers) can now propagate errors back to the system, supporting both fallible and non-fallible callbacks.
  * Ownership of message cleanup is clarified: when a handler exists, cleanup responsibility is transferred to the handler.

* **Bug Fixes**
  * Handler invocation failures are caught and logged with subscription details, and processing continues without double-cleanup.
  * Response and subscription paths now consistently propagate handler errors to reduce silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->