### PR TITLE
Validate stream/consumer names

### DIFF
--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -744,9 +744,8 @@ pub const JetStream = struct {
     /// Uses DURABLE endpoint only if durable_name is provided, otherwise creates ephemeral consumer.
     pub fn addConsumer(self: *JetStream, stream_name: []const u8, config: ConsumerConfig) !Result(ConsumerInfo) {
         try validateStreamName(stream_name);
-        if (config.durable_name) |name| {
-            try validateConsumerName(name);
-        }
+        if (config.name) |n| try validateConsumerName(n);
+        if (config.durable_name) |n| try validateConsumerName(n);
 
         log.info("adding consumer", .{});
         const subject = if (config.durable_name) |durable_name|


### PR DESCRIPTION
Multiple places validate them differenly, so it's hard to tell what's the official way, this seems like a good compromise.

Fixes https://github.com/lalinsky/nats.zig/issues/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public validators for stream and consumer names (reject empty/prohibited characters).
  - Status-aware push subscriptions: flow-control acking and heartbeat handling.
  - Two new public APIs (backward-compatible signatures).

- Bug Fixes
  - Consistent pre-validation of stream and consumer names across the API.
  - Enforced deliver-subject requirement and adjusted delivery handling for push subscriptions.
  - Pull-subscribe derives consumer name reliably after creation.

- Tests
  - Added tests for valid and invalid name inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->