### PR TITLE
Implement queueSubscribe() and queueSubscribeSync()

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -563,8 +563,15 @@ pub const Connection = struct {
 
         self.subs_mutex.lock();
         defer self.subs_mutex.unlock();
+
         try self.subscriptions.put(sub.sid, sub);
         sub.retain(); // Connection takes ownership reference
+
+        errdefer {
+            if (self.subscriptions.remove(sub.sid)) {
+                sub.release();
+            }
+        }
 
         // Send SUB command via buffer
         var buffer = ArrayList(u8).init(self.allocator);

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -5,6 +5,7 @@ const utils = @import("utils.zig");
 test {
     _ = @import("minimal_test.zig");
     _ = @import("headers_test.zig");
+    _ = @import("subscribe_test.zig");
     _ = @import("core_request_reply_test.zig");
     _ = @import("jetstream_test.zig");
     _ = @import("jetstream_stream_test.zig");

--- a/tests/subscribe_test.zig
+++ b/tests/subscribe_test.zig
@@ -15,15 +15,11 @@ test "subscribeSync smoke test" {
     try conn.publish("test", "Hello world!");
     try conn.flush();
 
-    const result = sub.nextMsg(1000);
-    defer if (result) |msg| msg.deinit();
+    const msg = sub.nextMsg(1000) orelse return error.Timeout;
+    defer msg.deinit();
 
-    if (result) |msg| {
-        try std.testing.expectEqualStrings("test", msg.subject);
-        try std.testing.expectEqualStrings("Hello world!", msg.data);
-    } else {
-        try std.testing.expect(false);
-    }
+    try std.testing.expectEqualStrings("test", msg.subject);
+    try std.testing.expectEqualStrings("Hello world!", msg.data);
 }
 
 test "queueSubscribeSync smoke test" {
@@ -36,59 +32,79 @@ test "queueSubscribeSync smoke test" {
     try conn.publish("test", "Hello world!");
     try conn.flush();
 
-    const result = sub.nextMsg(1000);
-    defer if (result) |msg| msg.deinit();
+    const msg = sub.nextMsg(1000) orelse return error.Timeout;
+    defer msg.deinit();
 
-    if (result) |msg| {
-        try std.testing.expectEqualStrings("test", msg.subject);
-        try std.testing.expectEqualStrings("Hello world!", msg.data);
-    } else {
-        try std.testing.expect(false);
+    try std.testing.expectEqualStrings("test", msg.subject);
+    try std.testing.expectEqualStrings("Hello world!", msg.data);
+}
+
+const MessageCollector = struct {
+    result: ?*Message = null,
+    mutex: std.Thread.Mutex = .{},
+    cond: std.Thread.Condition = .{},
+
+    pub fn deinit(self: *@This()) void {
+        if (self.result) |msg| msg.deinit();
     }
-}
 
-fn collectMsg(msg: *Message, result: *?*Message) !void {
-    result.* = msg;
-}
+    pub fn processMsg(msg: *Message, self: *@This()) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.result = msg;
+        self.cond.broadcast();
+    }
+
+    pub fn timedWait(self: *@This(), timeout_ms: u64) !*Message {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const timeout_ns = timeout_ms * std.time.ns_per_ms;
+        var timer = std.time.Timer.start() catch unreachable;
+        while (self.result == null) {
+            const elapsed_ns = timer.read();
+            if (elapsed_ns >= timeout_ns) {
+                return error.Timeout;
+            }
+            try self.cond.timedWait(&self.mutex, timeout_ns - elapsed_ns);
+        }
+        return self.result.?;
+    }
+};
 
 test "subscribe smoke test" {
     var conn = try utils.createDefaultConnection();
     defer utils.closeConnection(conn);
 
-    var result: ?*Message = null;
-    defer if (result) |msg| msg.deinit();
+    var collector: MessageCollector = .{};
+    defer collector.deinit();
 
-    const sub = try conn.subscribe("test", collectMsg, .{&result});
+    const sub = try conn.subscribe("test", MessageCollector.processMsg, .{&collector});
     defer sub.deinit();
 
     try conn.publish("test", "Hello world!");
     try conn.flush();
 
-    if (result) |msg| {
-        try std.testing.expectEqualStrings("test", msg.subject);
-        try std.testing.expectEqualStrings("Hello world!", msg.data);
-    } else {
-        try std.testing.expect(false);
-    }
+    const msg = try collector.timedWait(1000);
+    try std.testing.expectEqualStrings("test", msg.subject);
+    try std.testing.expectEqualStrings("Hello world!", msg.data);
 }
 
 test "queueSubscribe smoke test" {
     var conn = try utils.createDefaultConnection();
     defer utils.closeConnection(conn);
 
-    var result: ?*Message = null;
-    defer if (result) |msg| msg.deinit();
+    var collector: MessageCollector = .{};
+    defer collector.deinit();
 
-    const sub = try conn.queueSubscribe("test", "workers", collectMsg, .{&result});
+    const sub = try conn.queueSubscribe("test", "workers", MessageCollector.processMsg, .{&collector});
     defer sub.deinit();
 
     try conn.publish("test", "Hello world!");
     try conn.flush();
 
-    if (result) |msg| {
-        try std.testing.expectEqualStrings("test", msg.subject);
-        try std.testing.expectEqualStrings("Hello world!", msg.data);
-    } else {
-        try std.testing.expect(false);
-    }
+    const msg = try collector.timedWait(1000);
+    try std.testing.expectEqualStrings("test", msg.subject);
+    try std.testing.expectEqualStrings("Hello world!", msg.data);
 }

--- a/tests/subscribe_test.zig
+++ b/tests/subscribe_test.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const nats = @import("nats");
+const utils = @import("utils.zig");
+const Message = nats.Message;
+
+const log = std.log.scoped(.testing);
+
+test "subscribeSync smoke test" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("test");
+    defer sub.deinit();
+
+    try conn.publish("test", "Hello world!");
+    try conn.flush();
+
+    const result = sub.nextMsg(1000);
+    defer if (result) |msg| msg.deinit();
+
+    if (result) |msg| {
+        try std.testing.expectEqualStrings("test", msg.subject);
+        try std.testing.expectEqualStrings("Hello world!", msg.data);
+    } else {
+        try std.testing.expect(false);
+    }
+}
+
+test "queueSubscribeSync smoke test" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.queueSubscribeSync("test", "workers");
+    defer sub.deinit();
+
+    try conn.publish("test", "Hello world!");
+    try conn.flush();
+
+    const result = sub.nextMsg(1000);
+    defer if (result) |msg| msg.deinit();
+
+    if (result) |msg| {
+        try std.testing.expectEqualStrings("test", msg.subject);
+        try std.testing.expectEqualStrings("Hello world!", msg.data);
+    } else {
+        try std.testing.expect(false);
+    }
+}
+
+fn collectMsg(msg: *Message, result: *?*Message) !void {
+    result.* = msg;
+}
+
+test "subscribe smoke test" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var result: ?*Message = null;
+    defer if (result) |msg| msg.deinit();
+
+    const sub = try conn.subscribe("test", collectMsg, .{&result});
+    defer sub.deinit();
+
+    try conn.publish("test", "Hello world!");
+    try conn.flush();
+
+    if (result) |msg| {
+        try std.testing.expectEqualStrings("test", msg.subject);
+        try std.testing.expectEqualStrings("Hello world!", msg.data);
+    } else {
+        try std.testing.expect(false);
+    }
+}
+
+test "queueSubscribe smoke test" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var result: ?*Message = null;
+    defer if (result) |msg| msg.deinit();
+
+    const sub = try conn.queueSubscribe("test", "workers", collectMsg, .{&result});
+    defer sub.deinit();
+
+    try conn.publish("test", "Hello world!");
+    try conn.flush();
+
+    if (result) |msg| {
+        try std.testing.expectEqualStrings("test", msg.subject);
+        try std.testing.expectEqualStrings("Hello world!", msg.data);
+    } else {
+        try std.testing.expect(false);
+    }
+}


### PR DESCRIPTION
### TL;DR

Added queue subscription support to the NATS client library.

### What changed?

- Added `queueSubscribe` and `queueSubscribeSync` methods to the Connection struct
- Updated the Subscription struct to store an optional queue group name
- Modified the SUB command formatting to include queue group when present
- Updated the subscription initialization to accept queue group parameter
- Added proper memory management for queue group strings

### How to test?

The PR includes new tests in `subscribe_test.zig` that verify both regular and queue subscriptions:
- `subscribeSync` and `queueSubscribeSync` tests for synchronous subscriptions
- `subscribe` and `queueSubscribe` tests for asynchronous subscriptions with callbacks

Run the tests with:
```
zig build test
```

### Why make this change?

Queue subscriptions are a core feature of NATS that enable load balancing of messages across multiple subscribers. This implementation allows multiple subscribers to form a queue group where only one member receives each message, enabling horizontal scaling of message processing.