### PR TITLE
Enable NATS protocol version 1 support

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -791,6 +791,7 @@ pub const Connection = struct {
             .name = client_name,
             .lang = build_options.lang,
             .version = build_options.version,
+            .protocol = 1,
         };
 
         try buffer.writer().writeAll("CONNECT ");


### PR DESCRIPTION
## Summary
- Add `protocol: 1` to CONNECT message to enable NATS protocol version 1
- Enables asynchronous INFO message handling for dynamic cluster topology changes
- Allows server discovery via `connect_urls` field in INFO messages

## Changes
- Updated `processInitialHandshake()` in `src/connection.zig` to include `protocol: 1` in CONNECT message

## Benefits
- Improved cluster awareness during connection lifetime
- Dynamic server discovery when cluster topology changes
- Better reconnection capabilities with updated server information

## Test plan
- [x] All existing tests pass (107/107)
- [x] Connection lifecycle tests verify protocol compatibility
- [x] JetStream functionality remains intact
- [x] Request/reply operations work correctly