### PR TITLE
Refactor reconnection system to eliminate separate thread

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -574,8 +574,10 @@ pub const Connection = struct {
         }
 
         // Send SUB command via buffer
-        var buffer = ArrayList(u8).init(self.allocator);
-        defer buffer.deinit();
+        const allocator = self.scratch.allocator();
+        defer self.resetScratch();
+
+        var buffer = ArrayList(u8).init(allocator);
         if (sub.queue_group) |group| {
             try buffer.writer().print("SUB {s} {s} {d}\r\n", .{ sub.subject, group, sub.sid });
         } else {
@@ -663,8 +665,10 @@ pub const Connection = struct {
         }
 
         // Send UNSUB command
-        var buffer = ArrayList(u8).init(self.allocator);
-        defer buffer.deinit();
+        const allocator = self.scratch.allocator();
+        defer self.resetScratch();
+
+        var buffer = ArrayList(u8).init(allocator);
         try buffer.writer().print("UNSUB {d}\r\n", .{sub.sid});
         try self.bufferWrite(buffer.items);
 
@@ -1043,7 +1047,6 @@ pub const Connection = struct {
 
         // Build CONNECT message with all options
         var buffer = ArrayList(u8).init(allocator);
-        defer buffer.deinit();
 
         // Calculate effective no_responders: enable if server supports headers
         const no_responders = self.options.no_responders and self.server_info.headers;
@@ -1443,8 +1446,10 @@ pub const Connection = struct {
         self.subs_mutex.lock();
         defer self.subs_mutex.unlock();
 
-        var buffer = ArrayList(u8).init(self.allocator);
-        defer buffer.deinit();
+        const allocator = self.scratch.allocator();
+        defer self.resetScratch();
+
+        var buffer = ArrayList(u8).init(allocator);
 
         var iter = self.subscriptions.iterator();
         while (iter.next()) |entry| {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -154,7 +154,7 @@ pub const HandshakeState = enum {
 };
 
 pub const ReconnectOptions = struct {
-    max_reconnect: i32 = 60, // -1 = unlimited
+    max_reconnect: u32 = 60,
     reconnect_wait_ms: u64 = 2000, // milliseconds
     reconnect_jitter_ms: u64 = 100,
     reconnect_jitter_tls_ms: u64 = 1000,
@@ -1301,7 +1301,7 @@ pub const Connection = struct {
 
         var total_attempts: u32 = 0;
         var server_cycle_count: u32 = 0;
-        const max_attempts = @as(u32, @intCast(@max(0, self.options.reconnect.max_reconnect)));
+        const max_attempts = self.options.reconnect.max_reconnect;
 
         // Main reconnection loop (under mutex for state consistency)
         while (total_attempts < max_attempts and self.status == .reconnecting and !self.should_stop.load(.acquire)) {


### PR DESCRIPTION
- Remove dedicated reconnection thread, handle reconnection in reader loop
- Split socket coordination into available/unused condition variables
- Extract connection establishment into establishConnection() method
- Simplify reconnection state machine and improve error handling
- Clean up thread lifecycle management in close() method
- Remove reconnection-specific fields: reconnect_thread, in_reconnect, abort_reconnect