### PR TITLE
Change nextMsg() to return error.Timeout instead of null

### DIFF
--- a/benchmarks/echo_server.zig
+++ b/benchmarks/echo_server.zig
@@ -41,7 +41,7 @@ pub fn main() !void {
     // Wait for messages in a loop
     while (bench_util.keep_running) {
         // Wait for the next message (with timeout)
-        if (sub.nextMsg(1000)) |msg| {
+        if (sub.nextMsg(1000) catch null) |msg| {
             defer msg.deinit();
 
             stats.msg_count += 1;

--- a/benchmarks/subscriber.zig
+++ b/benchmarks/subscriber.zig
@@ -42,7 +42,7 @@ pub fn main() !void {
     // Wait for messages in a loop
     while (bench_util.keep_running) {
         // Wait for the next message (with timeout)
-        if (sub.nextMsg(1000)) |msg| {
+        if (sub.nextMsg(1000) catch null) |msg| {
             defer msg.deinit();
 
             stats.msg_count += 1;

--- a/examples/replier.zig
+++ b/examples/replier.zig
@@ -35,7 +35,7 @@ pub fn main() !void {
     // Wait for messages in a loop
     while (true) {
         // Wait for the next message (blocks until one arrives)
-        if (sub.nextMsg(1000)) |msg| {
+        if (sub.nextMsg(1000) catch null) |msg| {
             defer msg.deinit();
 
             std.debug.print("Received msg: {s} - {s}\n", .{ msg.subject, msg.data });

--- a/examples/sub.zig
+++ b/examples/sub.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
     const max_attempts = 50; // 50 * 100ms = 5 seconds
 
     while (attempts < max_attempts) {
-        if (sub.nextMsg(100)) |msg| {
+        if (sub.nextMsg(100) catch null) |msg| {
             defer msg.deinit();
 
             std.log.info("Received message: {s} - {s}", .{ msg.subject, msg.data });

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -510,9 +510,11 @@ pub const PullSubscription = struct {
 
                     try messages.append(js_msg_ptr);
                 }
-            } else {
-                // Timeout occurred
-                batch_complete = true;
+            } else |err| switch (err) {
+                error.Timeout => {
+                    // Timeout occurred
+                    batch_complete = true;
+                },
             }
         }
 
@@ -551,14 +553,14 @@ pub const JetStreamSubscription = struct {
     }
 
     /// Get the next JetStream message synchronously (for sync subscriptions)
-    pub fn nextMsg(self: *JetStreamSubscription, timeout_ms: u64) ?*JetStreamMessage {
+    pub fn nextMsg(self: *JetStreamSubscription, timeout_ms: u64) error{Timeout}!*JetStreamMessage {
         // Get the next message from the underlying subscription
-        const msg = self.subscription.nextMsg(timeout_ms) orelse return null;
+        const msg = self.subscription.nextMsg(timeout_ms) catch |err| return err;
 
         // Convert to JetStream message
         const js_msg = jetstream_message.createJetStreamMessage(self.js.nc, msg) catch {
             msg.deinit(); // Clean up on error
-            return null;
+            return error.Timeout; // Convert any error to Timeout for API consistency
         };
 
         return js_msg;

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -117,8 +117,8 @@ pub const Subscription = struct {
         self.release();
     }
 
-    pub fn nextMsg(self: *Subscription, timeout_ms: u64) ?*Message {
-        return self.messages.pop(timeout_ms) catch null;
+    pub fn nextMsg(self: *Subscription, timeout_ms: u64) error{Timeout}!*Message {
+        return self.messages.pop(timeout_ms) catch error.Timeout;
     }
 };
 

--- a/tests/headers_test.zig
+++ b/tests/headers_test.zig
@@ -25,7 +25,7 @@ test "publish and receive message with headers" {
     try conn.flush();
 
     // Receive the message
-    if (sub.nextMsg(1000)) |received_msg| {
+    if (sub.nextMsg(1000) catch null) |received_msg| {
         defer received_msg.deinit();
 
         // Verify basic message properties
@@ -66,7 +66,7 @@ test "publish message without headers using publishMsg" {
     try conn.flush();
 
     // Receive the message
-    if (sub.nextMsg(1000)) |received_msg| {
+    if (sub.nextMsg(1000) catch null) |received_msg| {
         defer received_msg.deinit();
 
         // Verify basic message properties
@@ -136,7 +136,7 @@ test "message with reply and headers" {
     try conn.flush();
 
     // Receive the message
-    if (sub.nextMsg(1000)) |received_msg| {
+    if (sub.nextMsg(1000) catch null) |received_msg| {
         defer received_msg.deinit();
 
         // Verify message properties

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -37,10 +37,7 @@ test "JetStream synchronous subscription basic functionality" {
     try conn.publish("test.sync.message", test_message);
 
     // Wait for message using nextMsg
-    const js_msg = sync_sub.nextMsg(5000) orelse {
-        try testing.expect(false); // Should have received a message
-        return;
-    };
+    const js_msg = try sync_sub.nextMsg(5000);
     defer js_msg.deinit(); // This cleans up everything via arena.deinit()
 
     // Verify message content
@@ -79,12 +76,12 @@ test "JetStream synchronous subscription timeout" {
     defer sync_sub.deinit();
     defer sync_sub.unsubscribe() catch {};
 
-    // Test timeout (should return null after timeout)
+    // Test timeout (should return error.Timeout after timeout)
     const start = std.time.milliTimestamp();
-    const js_msg = sync_sub.nextMsg(100); // 100ms timeout
+    const result = sync_sub.nextMsg(100); // 100ms timeout
     const duration = std.time.milliTimestamp() - start;
 
-    try testing.expectEqual(@as(?*nats.JetStreamMessage, null), js_msg);
+    try testing.expectError(error.Timeout, result);
     try testing.expect(duration >= 100); // Should have waited at least 100ms
 
     log.info("Synchronous subscription timeout test completed successfully", .{});
@@ -125,11 +122,7 @@ test "JetStream synchronous subscription multiple messages" {
 
     // Receive and verify all messages
     for (messages, 0..) |expected, i| {
-        const js_msg = sync_sub.nextMsg(5000) orelse {
-            log.err("Failed to receive message {}", .{i});
-            try testing.expect(false);
-            return;
-        };
+        const js_msg = try sync_sub.nextMsg(5000);
         defer js_msg.deinit(); // This cleans up everything via arena.deinit()
 
         try testing.expectEqualStrings(expected, js_msg.msg.data);

--- a/tests/minimal_test.zig
+++ b/tests/minimal_test.zig
@@ -29,7 +29,7 @@ test "basic publish and subscribe" {
     try conn.flush();
 
     // Try to receive the message
-    if (sub.nextMsg(100)) |msg| {
+    if (sub.nextMsg(100) catch null) |msg| {
         defer msg.deinit();
 
         try std.testing.expectEqualStrings("test.minimal", msg.subject);

--- a/tests/subscribe_test.zig
+++ b/tests/subscribe_test.zig
@@ -15,7 +15,7 @@ test "subscribeSync smoke test" {
     try conn.publish("test", "Hello world!");
     try conn.flush();
 
-    const msg = sub.nextMsg(1000) orelse return error.Timeout;
+    const msg = try sub.nextMsg(1000);
     defer msg.deinit();
 
     try std.testing.expectEqualStrings("test", msg.subject);
@@ -32,7 +32,7 @@ test "queueSubscribeSync smoke test" {
     try conn.publish("test", "Hello world!");
     try conn.flush();
 
-    const msg = sub.nextMsg(1000) orelse return error.Timeout;
+    const msg = try sub.nextMsg(1000);
     defer msg.deinit();
 
     try std.testing.expectEqualStrings("test", msg.subject);


### PR DESCRIPTION
Changes nextMsg() return type from ?*Message to error{Timeout}!*Message and updates all call sites.

Fixes #75

🤖 Generated with [Claude Code](https://claude.ai/code)