### PR TITLE
Fix unsubscribe to not fail on closed connections

### DIFF
--- a/src/request_reply_test.zig
+++ b/src/request_reply_test.zig
@@ -99,7 +99,6 @@ test "unsubscribe functionality" {
     const sub = try Subscription.init(allocator, 1, "test.subject", null);
     defer sub.deinit();
 
-    // Test that unsubscribe fails when disconnected
-    const result = conn.unsubscribe(sub);
-    try std.testing.expectError(ConnectionError.ConnectionClosed, result);
+    // Test that unsubscribe succeeds when disconnected (graceful cleanup)
+    try conn.unsubscribe(sub);
 }


### PR DESCRIPTION
Fixes #78

This PR makes the unsubscribe operation graceful when the connection is in a closed state.

## Changes
- Modified unsubscribe method to always perform local cleanup
- Only send UNSUB protocol message when connection is active
- Updated test to expect success instead of ConnectionClosed error

## Benefits
- Eliminates need for `catch {}` in cleanup code
- Makes unsubscribe consistent with typical cleanup operation semantics
- Simplifies error handling for applications

Generated with [Claude Code](https://claude.ai/code)