### PR TITLE
Implement eager header parsing in main parser state machine

### DIFF
--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -478,7 +478,7 @@ pub const PullSubscription = struct {
                 // The timestamp in the ACK subject ensures messages belong to this fetch request
                 // (timestamps are monotonically increasing and unique per message delivery)
 
-                if (raw_msg.headerGet("status")) |status_code| {
+                if (raw_msg.headerGet("Status")) |status_code| {
                     if (std.mem.eql(u8, status_code, "404")) {
                         // No messages available
                         raw_msg.deinit();

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -478,7 +478,7 @@ pub const PullSubscription = struct {
                 // The timestamp in the ACK subject ensures messages belong to this fetch request
                 // (timestamps are monotonically increasing and unique per message delivery)
 
-                if (try raw_msg.headerGet("Status")) |status_code| {
+                if (raw_msg.headerGet("Status")) |status_code| {
                     if (std.mem.eql(u8, status_code, "404")) {
                         // No messages available
                         raw_msg.deinit();
@@ -911,8 +911,7 @@ pub const JetStream = struct {
             const hdrs_len = try decoder.calcSizeForSlice(hdrs_b64);
             const decoded_headers = try arena_allocator.alloc(u8, hdrs_len);
             try decoder.decode(decoded_headers, hdrs_b64);
-            msg.raw_headers = decoded_headers;
-            msg.needs_header_parsing = true;
+            try msg.parseHeaders(decoded_headers);
         }
 
         // Parse time from RFC3339 format

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -478,7 +478,7 @@ pub const PullSubscription = struct {
                 // The timestamp in the ACK subject ensures messages belong to this fetch request
                 // (timestamps are monotonically increasing and unique per message delivery)
 
-                if (raw_msg.headerGet("Status")) |status_code| {
+                if (raw_msg.headerGet("status")) |status_code| {
                     if (std.mem.eql(u8, status_code, "404")) {
                         // No messages available
                         raw_msg.deinit();

--- a/src/message.zig
+++ b/src/message.zig
@@ -152,18 +152,18 @@ pub const Message = struct {
                     status = status_part; // Less than 3 chars, use as-is
                 }
 
-                // Add Status header (normalized to lowercase)
+                // Add Status header
                 const owned_status = try arena_allocator.dupe(u8, status);
                 var status_list = ArrayListUnmanaged([]const u8){};
                 try status_list.append(arena_allocator, owned_status);
-                try self.headers.put(arena_allocator, "status", status_list);
+                try self.headers.put(arena_allocator, HDR_STATUS, status_list);
 
-                // Add Description header if present (normalized to lowercase)
+                // Add Description header if present
                 if (description) |desc| {
                     const owned_desc = try arena_allocator.dupe(u8, desc);
                     var desc_list = ArrayListUnmanaged([]const u8){};
                     try desc_list.append(arena_allocator, owned_desc);
-                    try self.headers.put(arena_allocator, "description", desc_list);
+                    try self.headers.put(arena_allocator, HDR_DESCRIPTION, desc_list);
                 }
             }
         }
@@ -177,11 +177,8 @@ pub const Message = struct {
 
             if (key.len == 0) continue;
 
-            // Normalize key to lowercase for case-insensitive matching
-            const owned_key = try arena_allocator.alloc(u8, key.len);
-            for (key, 0..) |c, i| {
-                owned_key[i] = std.ascii.toLower(c);
-            }
+            // Copy key and value using arena
+            const owned_key = try arena_allocator.dupe(u8, key);
             const owned_value = try arena_allocator.dupe(u8, value);
 
             const result = try self.headers.getOrPut(arena_allocator, owned_key);
@@ -215,23 +212,11 @@ pub const Message = struct {
             }
         }
 
-        // Normalize key for removal (case-insensitive)
-        var lower_key_buf: [256]u8 = undefined;
-        const lower_key = if (key.len <= lower_key_buf.len) blk: {
-            for (key, 0..) |c, i| {
-                lower_key_buf[i] = std.ascii.toLower(c);
-            }
-            break :blk lower_key_buf[0..key.len];
-        } else key; // Fallback for very long keys
-
         // Remove existing values (arena will clean up memory automatically)
-        _ = self.headers.fetchRemove(lower_key);
+        _ = self.headers.fetchRemove(key);
 
-        // Normalize key to lowercase for case-insensitive matching
-        const owned_key = try arena_allocator.alloc(u8, key.len);
-        for (key, 0..) |c, i| {
-            owned_key[i] = std.ascii.toLower(c);
-        }
+        // Copy key and value using arena
+        const owned_key = try arena_allocator.dupe(u8, key);
         const owned_value = try arena_allocator.dupe(u8, value);
 
         var values: ArrayListUnmanaged([]const u8) = .{};
@@ -241,16 +226,7 @@ pub const Message = struct {
     }
 
     pub fn headerGet(self: *Self, key: []const u8) ?[]const u8 {
-        // Create lowercase key for lookup (case-insensitive)
-        var lower_key_buf: [256]u8 = undefined;
-        const lower_key = if (key.len <= lower_key_buf.len) blk: {
-            for (key, 0..) |c, i| {
-                lower_key_buf[i] = std.ascii.toLower(c);
-            }
-            break :blk lower_key_buf[0..key.len];
-        } else key; // Fallback for very long keys
-
-        if (self.headers.get(lower_key)) |values| {
+        if (self.headers.get(key)) |values| {
             if (values.items.len > 0) {
                 return values.items[0];
             }
@@ -260,16 +236,7 @@ pub const Message = struct {
     }
 
     pub fn headerGetAll(self: *Self, key: []const u8) ?[]const []const u8 {
-        // Create lowercase key for lookup (case-insensitive)
-        var lower_key_buf: [256]u8 = undefined;
-        const lower_key = if (key.len <= lower_key_buf.len) blk: {
-            for (key, 0..) |c, i| {
-                lower_key_buf[i] = std.ascii.toLower(c);
-            }
-            break :blk lower_key_buf[0..key.len];
-        } else key; // Fallback for very long keys
-
-        if (self.headers.get(lower_key)) |values| {
+        if (self.headers.get(key)) |values| {
             return values.items; // No copy needed - arena owns the data
         }
 
@@ -277,24 +244,15 @@ pub const Message = struct {
     }
 
     pub fn headerDelete(self: *Self, key: []const u8) void {
-        // Create lowercase key for deletion (case-insensitive)
-        var lower_key_buf: [256]u8 = undefined;
-        const lower_key = if (key.len <= lower_key_buf.len) blk: {
-            for (key, 0..) |c, i| {
-                lower_key_buf[i] = std.ascii.toLower(c);
-            }
-            break :blk lower_key_buf[0..key.len];
-        } else key; // Fallback for very long keys
-
         // Arena will clean up memory automatically
-        _ = self.headers.fetchRemove(lower_key);
+        _ = self.headers.fetchRemove(key);
     }
 
     // Check if message indicates "no responders" - matches Go NATS library logic
     pub fn isNoResponders(self: *Self) bool {
         if (self.data.len != 0) return false;
 
-        const status = self.headerGet("status");
+        const status = self.headerGet(HDR_STATUS);
         return status != null and std.mem.eql(u8, status.?, HDR_STATUS_NO_RESPONSE);
     }
 

--- a/src/message.zig
+++ b/src/message.zig
@@ -89,21 +89,6 @@ pub const Message = struct {
         };
     }
 
-    // Create message with headers pre-parsed
-    pub fn initWithHeaders(allocator: std.mem.Allocator, subject: []const u8, reply: ?[]const u8, data: []const u8, raw_headers: []const u8) !Self {
-        var msg = Self.init(allocator);
-        errdefer msg.deinit();
-
-        try msg.setSubject(subject);
-        if (reply) |r| {
-            try msg.setReply(r);
-        }
-        try msg.setPayload(data);
-        try msg.parseHeaders(raw_headers);
-
-        return msg;
-    }
-
     pub fn deinit(self: *Self) void {
         if (self.pool) |pool| {
             pool.release(self);

--- a/src/message_test.zig
+++ b/src/message_test.zig
@@ -45,7 +45,7 @@ test "Message with headers" {
     try testing.expectEqualStrings("hello world", msg.data);
 
     // Verify headers
-    const content_type = try msg.headerGet("Content-Type");
+    const content_type = msg.headerGet("Content-Type");
     try testing.expectEqualStrings("application/json", content_type.?);
 }
 
@@ -60,19 +60,19 @@ test "Message header management" {
     try msg.headerSet("Custom-Header", "value1");
 
     // Get headers
-    const content_type = try msg.headerGet("Content-Type");
+    const content_type = msg.headerGet("Content-Type");
     try testing.expectEqualStrings("application/json", content_type.?);
 
-    const custom = try msg.headerGet("Custom-Header");
+    const custom = msg.headerGet("Custom-Header");
     try testing.expectEqualStrings("value1", custom.?);
 
     // Non-existent header
-    const missing = try msg.headerGet("Missing");
+    const missing = msg.headerGet("Missing");
     try testing.expectEqual(@as(?[]const u8, null), missing);
 
     // Delete header
-    try msg.headerDelete("Content-Type");
-    const deleted = try msg.headerGet("Content-Type");
+    msg.headerDelete("Content-Type");
+    const deleted = msg.headerGet("Content-Type");
     try testing.expectEqual(@as(?[]const u8, null), deleted);
 }
 
@@ -89,14 +89,14 @@ test "Message lazy header parsing" {
     try testing.expect(msg.needs_header_parsing);
 
     // First access should parse headers
-    const content_type = try msg.headerGet("Content-Type");
+    const content_type = msg.headerGet("Content-Type");
     try testing.expectEqualStrings("application/json", content_type.?);
 
     // Should no longer need parsing
     try testing.expect(!msg.needs_header_parsing);
 
     // Verify other headers were parsed
-    const custom = try msg.headerGet("X-Custom");
+    const custom = msg.headerGet("X-Custom");
     try testing.expectEqualStrings("test-value", custom.?);
 }
 
@@ -164,8 +164,8 @@ test "Message error handling" {
 
     // Empty header operations should work
     try msg.headerSet("", "value");
-    try msg.headerDelete("nonexistent");
+    msg.headerDelete("nonexistent");
 
-    const result = try msg.headerGet("");
+    const result = msg.headerGet("");
     try testing.expectEqualStrings("value", result.?);
 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -256,9 +256,7 @@ pub const Parser = struct {
                             const trimmed_name = std.mem.trim(u8, header_name_slice, " \t");
 
                             if (trimmed_name.len > 0) {
-                                const msg = self.ma.msg orelse unreachable;
-                                const arena_allocator = msg.arena.allocator();
-                                self.ma.current_header_name = try arena_allocator.dupe(u8, trimmed_name);
+                                self.ma.current_header_name = trimmed_name;
                             }
 
                             self.state = .HMSG_HEADER_COLON;
@@ -313,13 +311,11 @@ pub const Parser = struct {
                                 const arena_allocator = msg.arena.allocator();
 
                                 if (trimmed_value.len > 0) {
-                                    const owned_value = try arena_allocator.dupe(u8, trimmed_value);
-
                                     const result = try msg.headers.getOrPut(arena_allocator, header_name);
                                     if (!result.found_existing) {
                                         result.value_ptr.* = .{};
                                     }
-                                    try result.value_ptr.append(arena_allocator, owned_value);
+                                    try result.value_ptr.append(arena_allocator, trimmed_value);
                                 }
 
                                 self.ma.current_header_name = null;
@@ -674,16 +670,14 @@ pub const Parser = struct {
                 }
 
                 // Add Status header
-                const owned_status = try arena_allocator.dupe(u8, status);
                 var status_list = ArrayListUnmanaged([]const u8){};
-                try status_list.append(arena_allocator, owned_status);
+                try status_list.append(arena_allocator, status);
                 try msg.headers.put(arena_allocator, "Status", status_list);
 
                 // Add Description header if present
                 if (description) |desc| {
-                    const owned_desc = try arena_allocator.dupe(u8, desc);
                     var desc_list = ArrayListUnmanaged([]const u8){};
-                    try desc_list.append(arena_allocator, owned_desc);
+                    try desc_list.append(arena_allocator, desc);
                     try msg.headers.put(arena_allocator, "Description", desc_list);
                 }
             }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -310,13 +310,8 @@ pub const Parser = struct {
                                 const arena_allocator = msg.arena.allocator();
 
                                 if (trimmed_value.len > 0) {
-                                    // Normalize header name to lowercase for case-insensitive matching
-                                    const normalized_key = try arena_allocator.alloc(u8, header_name.len);
-                                    for (header_name, 0..) |c, j| {
-                                        normalized_key[j] = std.ascii.toLower(c);
-                                    }
-
-                                    const result = try msg.headers.getOrPut(arena_allocator, normalized_key);
+                                    // Use original header name (case-sensitive)
+                                    const result = try msg.headers.getOrPut(arena_allocator, header_name);
                                     if (!result.found_existing) {
                                         result.value_ptr.* = .{};
                                     }
@@ -677,13 +672,13 @@ pub const Parser = struct {
                 // Add Status header
                 var status_list = std.ArrayListUnmanaged([]const u8){};
                 try status_list.append(arena_allocator, status);
-                try msg.headers.put(arena_allocator, "status", status_list);
+                try msg.headers.put(arena_allocator, "Status", status_list);
 
                 // Add Description header if present
                 if (description) |desc| {
                     var desc_list = std.ArrayListUnmanaged([]const u8){};
                     try desc_list.append(arena_allocator, desc);
-                    try msg.headers.put(arena_allocator, "description", desc_list);
+                    try msg.headers.put(arena_allocator, "Description", desc_list);
                 }
             }
         }
@@ -972,7 +967,7 @@ test "parser split hmsg" {
         if (capture.last_msg) |msg| {
             try std.testing.expectEqualStrings("foo", msg.subject);
             try std.testing.expectEqualStrings("hello", msg.data);
-            try std.testing.expectEqualStrings("Bar", msg.headerGet("foo") orelse "");
+            try std.testing.expectEqualStrings("Bar", msg.headerGet("Foo") orelse "");
         } else {
             try std.testing.expect(false);
         }

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -19,6 +19,7 @@ test {
     _ = @import("jetstream_msg_test.zig");
     _ = @import("jetstream_duplicate_ack_test.zig");
     _ = @import("jetstream_large_list_test.zig");
+    _ = @import("message_test.zig");
 }
 
 test "tests:beforeEach" {

--- a/tests/headers_test.zig
+++ b/tests/headers_test.zig
@@ -33,11 +33,11 @@ test "publish and receive message with headers" {
     try std.testing.expectEqualStrings("Hello with headers!", received_msg.data);
 
     // Verify headers
-    const test_key_value = try received_msg.headerGet("X-Test-Key");
+    const test_key_value = received_msg.headerGet("X-Test-Key");
     try std.testing.expect(test_key_value != null);
     try std.testing.expectEqualStrings("test-value", test_key_value.?);
 
-    const another_key_value = try received_msg.headerGet("X-Another-Key");
+    const another_key_value = received_msg.headerGet("X-Another-Key");
     try std.testing.expect(another_key_value != null);
     try std.testing.expectEqualStrings("another-value", another_key_value.?);
 
@@ -83,25 +83,25 @@ test "header manipulation API" {
     try msg.headerSet("X-Custom-Header", "custom-value");
 
     // Get headers
-    const content_type = try msg.headerGet("Content-Type");
+    const content_type = msg.headerGet("Content-Type");
     try std.testing.expect(content_type != null);
     try std.testing.expectEqualStrings("application/json", content_type.?);
 
-    const custom_header = try msg.headerGet("X-Custom-Header");
+    const custom_header = msg.headerGet("X-Custom-Header");
     try std.testing.expect(custom_header != null);
     try std.testing.expectEqualStrings("custom-value", custom_header.?);
 
     // Test non-existent header
-    const non_existent = try msg.headerGet("Non-Existent-Header");
+    const non_existent = msg.headerGet("Non-Existent-Header");
     try std.testing.expect(non_existent == null);
 
     // Delete a header
-    try msg.headerDelete("X-Custom-Header");
-    const deleted_header = try msg.headerGet("X-Custom-Header");
+    msg.headerDelete("X-Custom-Header");
+    const deleted_header = msg.headerGet("X-Custom-Header");
     try std.testing.expect(deleted_header == null);
 
     // Content-Type should still exist
-    const still_exists = try msg.headerGet("Content-Type");
+    const still_exists = msg.headerGet("Content-Type");
     try std.testing.expect(still_exists != null);
     try std.testing.expectEqualStrings("application/json", still_exists.?);
 
@@ -139,11 +139,11 @@ test "message with reply and headers" {
     try std.testing.expectEqualStrings("Request with headers", received_msg.data);
 
     // Verify headers
-    const request_id = try received_msg.headerGet("Request-ID");
+    const request_id = received_msg.headerGet("Request-ID");
     try std.testing.expect(request_id != null);
     try std.testing.expectEqualStrings("12345", request_id.?);
 
-    const content_type = try received_msg.headerGet("Content-Type");
+    const content_type = received_msg.headerGet("Content-Type");
     try std.testing.expect(content_type != null);
     try std.testing.expectEqualStrings("text/plain", content_type.?);
 
@@ -155,7 +155,7 @@ test "no responders header detection" {
     var msg = nats.Message.init(std.testing.allocator);
     defer msg.deinit();
 
-    try msg.setRawHeaders("NATS/1.0 503\r\n");
+    try msg.parseHeaders("NATS/1.0 503\r\n");
 
     // Test no responders detection
     const is_no_responders = msg.isNoResponders();

--- a/tests/jetstream_msg_test.zig
+++ b/tests/jetstream_msg_test.zig
@@ -206,11 +206,11 @@ test "get message with headers" {
     try testing.expectEqual(@as(u64, 1), retrieved.seq);
 
     // Verify headers are preserved
-    const test_header = try retrieved.headerGet("X-Test-Header");
+    const test_header = retrieved.headerGet("X-Test-Header");
     try testing.expect(test_header != null);
     try testing.expectEqualStrings("test-value", test_header.?);
 
-    const another_header = try retrieved.headerGet("X-Another-Header");
+    const another_header = retrieved.headerGet("X-Another-Header");
     try testing.expect(another_header != null);
     try testing.expectEqualStrings("another-value", another_header.?);
 }

--- a/tests/message_test.zig
+++ b/tests/message_test.zig
@@ -40,8 +40,12 @@ test "Message with headers" {
     const raw_headers = "NATS/1.0\r\nContent-Type: application/json\r\nX-Custom: test-value\r\n\r\n";
 
     // Create message with headers
-    var msg = try Message.initWithHeaders(allocator, "test.subject", "reply.to", "hello world", raw_headers);
+    var msg = Message.init(allocator);
     defer msg.deinit();
+    try msg.setSubject("test.subject");
+    try msg.setReply("reply.to");
+    try msg.setPayload("hello world");
+    try msg.parseHeaders(raw_headers);
 
     // Verify data was copied (not same pointers)
     try testing.expectEqualStrings("test.subject", msg.subject);
@@ -89,8 +93,11 @@ test "Message eager header parsing" {
     // Raw headers as they would come from network
     const raw_headers = "NATS/1.0\r\nContent-Type: application/json\r\nX-Custom: test-value\r\n\r\n";
 
-    var msg = try Message.initWithHeaders(allocator, "test.subject", null, "hello world", raw_headers);
+    var msg = Message.init(allocator);
     defer msg.deinit();
+    try msg.setSubject("test.subject");
+    try msg.setPayload("hello world");
+    try msg.parseHeaders(raw_headers);
 
     // Headers are already parsed during initialization
     const content_type = msg.headerGet("Content-Type");

--- a/tests/message_test.zig
+++ b/tests/message_test.zig
@@ -141,9 +141,9 @@ test "Message header encoding" {
     // Should start with NATS/1.0
     try testing.expect(std.mem.startsWith(u8, buf.items, "NATS/1.0\r\n"));
 
-    // Should contain headers
-    try testing.expect(std.mem.indexOf(u8, buf.items, "Content-Type: application/json\r\n") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "X-Custom: value\r\n") != null);
+    // Should contain headers (normalized to lowercase)
+    try testing.expect(std.mem.indexOf(u8, buf.items, "content-type: application/json\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "x-custom: value\r\n") != null);
 
     // Should end with double CRLF
     try testing.expect(std.mem.endsWith(u8, buf.items, "\r\n\r\n"));
@@ -176,10 +176,40 @@ test "Message error handling" {
     try msg.setSubject("");
     try msg.setPayload("");
 
-    // Empty header operations should work
-    try msg.headerSet("", "value");
     msg.headerDelete("nonexistent");
 
-    const result = msg.headerGet("");
-    try testing.expectEqualStrings("value", result.?);
+    // Test header injection prevention
+    try testing.expectError(error.InvalidHeaderName, msg.headerSet("", "value"));
+    try testing.expectError(error.InvalidHeaderValue, msg.headerSet("Valid", "hello\nworld"));
+    try testing.expectError(error.InvalidHeaderValue, msg.headerSet("Valid", "hello\rworld"));
+    try testing.expectError(error.InvalidHeaderName, msg.headerSet("Bad\rName", "value"));
+    try testing.expectError(error.InvalidHeaderName, msg.headerSet("Bad\nName", "value"));
+    try testing.expectError(error.InvalidHeaderName, msg.headerSet("Bad:Name", "value"));
+}
+
+test "Message case-insensitive headers" {
+    const allocator = testing.allocator;
+
+    var msg = Message.init(allocator);
+    defer msg.deinit();
+
+    try msg.setSubject("test");
+    try msg.setPayload("data");
+
+    // Set header with mixed case
+    try msg.headerSet("Content-Type", "application/json");
+
+    // Should be retrievable with different case variations
+    try testing.expectEqualStrings("application/json", msg.headerGet("content-type").?);
+    try testing.expectEqualStrings("application/json", msg.headerGet("CONTENT-TYPE").?);
+    try testing.expectEqualStrings("application/json", msg.headerGet("Content-Type").?);
+
+    // Test case-insensitive deletion
+    msg.headerDelete("CONTENT-TYPE");
+    try testing.expectEqual(@as(?[]const u8, null), msg.headerGet("content-type"));
+
+    // Test case-insensitive overwrite
+    try msg.headerSet("X-Custom", "value1");
+    try msg.headerSet("x-custom", "value2"); // Should overwrite
+    try testing.expectEqualStrings("value2", msg.headerGet("X-CUSTOM").?);
 }


### PR DESCRIPTION
Implements eager header parsing in the main protocol parser state machine to improve performance for JetStream usage patterns.

## Changes

- Add HMSG_HEADERS parser state for eager header processing
- Parse headers immediately as bytes arrive instead of lazy parsing
- Remove lazy parsing infrastructure (raw_headers, needs_header_parsing, ensureHeadersParsed)
- Simplify header API methods to not return error unions
- Update JetStream to use new parseHeaders() method

## Benefits

- Better performance: Parse once during protocol parsing vs. on first access
- Simpler code: Eliminate lazy parsing complexity and flags
- Memory efficiency: No raw header storage, direct HashMap population
- Consistent with usage pattern: Headers parsed when they'll definitely be used

Closes #92

Generated with [Claude Code](https://claude.ai/code)