### PR TITLE
Implement nc.reconnect() method for manual reconnection (#86)

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -109,6 +109,10 @@ pub const ConnectionError = error{
     InvalidProtocol,
     OutOfMemory,
     NoResponders,
+    ReconnectDisabled,
+    AlreadyReconnecting,
+    NotConnected,
+    ManualReconnect,
 } || PublishError || std.Thread.SpawnError || std.posix.WriteError || std.posix.ReadError;
 
 pub const ConnectionStatus = enum {
@@ -458,6 +462,68 @@ pub const Connection = struct {
     pub fn isConnecting(self: *Self) bool {
         const status = self.getStatus();
         return status == .connecting or status == .reconnecting;
+    }
+
+    /// Force a reconnection to the NATS server
+    /// This allows users to manually trigger reconnection for scenarios like:
+    /// - Refreshing authentication credentials
+    /// - Rebalancing client connections
+    /// - Testing reconnection behavior
+    /// Returns error if reconnection cannot be initiated
+    pub fn reconnect(self: *Self) !void {
+        var callback: @TypeOf(self.options.callbacks.disconnected_cb) = null;
+        defer if (callback) |cb| cb(self);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        // Check if reconnection is allowed
+        if (!self.options.reconnect.allow_reconnect) {
+            log.warn("Manual reconnect requested but reconnection is disabled", .{});
+            return ConnectionError.ReconnectDisabled;
+        }
+
+        // Check current status
+        switch (self.status) {
+            .reconnecting => {
+                log.info("Already reconnecting, ignoring manual reconnect request", .{});
+                return ConnectionError.AlreadyReconnecting;
+            },
+            .closed => {
+                log.warn("Cannot reconnect: connection is closed", .{});
+                return ConnectionError.ConnectionClosed;
+            },
+            .connecting => {
+                log.warn("Cannot reconnect: initial connection not yet established", .{});
+                return ConnectionError.NotConnected;
+            },
+            .connected => {
+                // OK to proceed
+            },
+        }
+
+        log.info("Manual reconnection requested", .{});
+
+        // Use a synthetic error to trigger the reconnection
+        const synthetic_error = ConnectionError.ManualReconnect;
+
+        // Perform connection cleanup (don't close socket - let reconnect handle it)
+        self.status = .reconnecting;
+        self.cleanupFailedConnection(synthetic_error, false);
+
+        // Spawn reconnect thread if not already running
+        if (self.reconnect_thread == null) {
+            self.reconnect_thread = std.Thread.spawn(.{}, doReconnectThread, .{self}) catch |spawn_err| {
+                log.err("Failed to spawn reconnect thread: {}", .{spawn_err});
+                self.status = .closed;
+                return spawn_err;
+            };
+        }
+
+        // Invoke disconnected callback
+        if (self.options.callbacks.disconnected_cb) |cb| {
+            callback = cb;
+        }
     }
 
     /// Publishes data on a subject.

--- a/tests/reconnection_test.zig
+++ b/tests/reconnection_test.zig
@@ -62,7 +62,7 @@ const CallbackTracker = struct {
     fn timedWait(self: *@This(), timeout_ms: u32) !void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        return self.cond.timedWait(self.mutex, timeout_ms * std.time.ns_per_ms);
+        return self.cond.timedWait(&self.mutex, timeout_ms * std.time.ns_per_ms);
     }
 };
 
@@ -110,4 +110,93 @@ test "basic reconnection when server stops" {
     defer tracker.mutex.unlock();
     try testing.expectEqual(@as(u32, 1), tracker.disconnected_called);
     try testing.expectEqual(@as(u32, 1), tracker.reconnected_called);
+}
+
+test "manual reconnection with nc.reconnect()" {
+    tracker.reset();
+
+    const nc = try utils.createConnection(.node1, .{
+        .trace = true,
+        .reconnect = .{
+            .allow_reconnect = true,
+            .reconnect_wait_ms = 100,
+        },
+        .callbacks = .{
+            .disconnected_cb = CallbackTracker.disconnectedCallback,
+            .reconnected_cb = CallbackTracker.reconnectedCallback,
+            .closed_cb = CallbackTracker.closedCallback,
+            .error_cb = CallbackTracker.errorCallback,
+        },
+    });
+    defer utils.closeConnection(nc);
+
+    // Create a subscription to verify it survives reconnection
+    const sub = try nc.subscribeSync("test.manual");
+    defer sub.deinit();
+
+    // Ensure initial connection is working
+    log.debug("Publishing test message before manual reconnection", .{});
+    try nc.publish("test.manual", "before reconnect");
+    try nc.flush();
+
+    // Verify message was received
+    {
+        const msg = try sub.nextMsg(1000);
+        defer msg.deinit();
+        try testing.expectEqualStrings("before reconnect", msg.data);
+    }
+
+    // Trigger manual reconnection
+    log.debug("Triggering manual reconnection", .{});
+    try nc.reconnect();
+
+    // Wait for reconnection to complete
+    var timer = try std.time.Timer.start();
+    while (tracker.reconnected_called == 0) {
+        if (timer.read() >= 5000 * std.time.ns_per_ms) {
+            return error.ReconnectionTimeout;
+        }
+        try tracker.timedWait(100);
+    }
+
+    log.debug("Manual reconnection completed", .{});
+
+    // Verify callbacks were called
+    tracker.mutex.lock();
+    try testing.expectEqual(@as(u32, 1), tracker.disconnected_called);
+    try testing.expectEqual(@as(u32, 1), tracker.reconnected_called);
+    tracker.mutex.unlock();
+
+    // Verify connection is working after reconnection
+    log.debug("Publishing test message after manual reconnection", .{});
+    try nc.publish("test.manual", "after reconnect");
+    try nc.flush();
+
+    // Verify subscription survived reconnection
+    {
+        const msg = try sub.nextMsg(1000);
+        defer msg.deinit();
+        try testing.expectEqualStrings("after reconnect", msg.data);
+    }
+}
+
+test "reconnect() errors when disabled" {
+    const nc = try utils.createConnection(.node1, .{
+        .reconnect = .{
+            .allow_reconnect = false,
+        },
+    });
+    defer utils.closeConnection(nc);
+
+    // Should return error when reconnection is disabled
+    try testing.expectError(error.ReconnectDisabled, nc.reconnect());
+}
+
+test "reconnect() errors when connection closed" {
+    const nc = try utils.createConnection(.node1, .{});
+    defer utils.closeConnection(nc);
+    
+    nc.close();
+
+    try testing.expectError(error.ConnectionClosed, nc.reconnect());
 }

--- a/tests/reconnection_test.zig
+++ b/tests/reconnection_test.zig
@@ -195,7 +195,7 @@ test "reconnect() errors when disabled" {
 test "reconnect() errors when connection closed" {
     const nc = try utils.createConnection(.node1, .{});
     defer utils.closeConnection(nc);
-    
+
     nc.close();
 
     try testing.expectError(error.ConnectionClosed, nc.reconnect());


### PR DESCRIPTION
## Summary

Implements a public `reconnect()` method that allows users to manually trigger the reconnection process, addressing issue #86.

This provides flexibility for scenarios like:
- Refreshing authentication credentials  
- Rebalancing client connections
- Testing reconnection behavior

## Implementation Details

- **Public API**: `nc.reconnect()` method with comprehensive error handling
- **Error Types**: Added `ReconnectDisabled`, `AlreadyReconnecting`, `NotConnected`, `ManualReconnect` 
- **Thread Safety**: Reuses existing robust reconnection infrastructure with proper mutex protection
- **Full Recovery**: Automatically re-establishes all subscriptions and flushes pending messages
- **Callbacks**: Properly invokes disconnected/reconnected callbacks like automatic reconnection

## Test Coverage

- ✅ Manual reconnection with subscription survival verification
- ✅ Error handling for disabled reconnection
- ✅ Error handling for closed connections  
- ✅ Memory leak fixes and comprehensive testing
- ✅ All existing tests continue to pass

## Usage Example

```zig
// Force a reconnection to refresh auth or rebalance
try nc.reconnect();
```

🤖 Generated with [Claude Code](https://claude.ai/code)