### PR TITLE
Implement Phase 1: Subscription drain functionality

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1095,6 +1095,12 @@ pub const Connection = struct {
         if (sub) |s| {
             defer s.release(); // Release when done
 
+            // Check if subscription is draining - if so, drop new messages
+            if (s.draining) {
+                log.debug("Dropping message for draining subscription {d}: {s}", .{ message.sid, message.data });
+                return;
+            }
+
             // Log before consuming message (to avoid use-after-free)
             log.debug("Delivering message to subscription {d}: {s}", .{ message.sid, message.data });
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1096,8 +1096,8 @@ pub const Connection = struct {
             defer s.release(); // Release when done
 
             // Check if subscription is draining - if so, drop new messages
-            if (s.draining) {
-                log.debug("Dropping message for draining subscription {d}: {s}", .{ message.sid, message.data });
+            if (s.isDraining()) {
+                log.debug("Dropping message for draining subscription {d} ({} bytes)", .{ message.sid, message.data.len });
                 return;
             }
 

--- a/tests/subscribe_test.zig
+++ b/tests/subscribe_test.zig
@@ -108,3 +108,96 @@ test "queueSubscribe smoke test" {
     try std.testing.expectEqualStrings("test", msg.subject);
     try std.testing.expectEqualStrings("Hello world!", msg.data);
 }
+
+test "subscription drain functionality" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("test.drain");
+    defer sub.deinit();
+
+    // Send a message before draining
+    try conn.publish("test.drain", "message 1");
+    try conn.flush();
+
+    // Receive the first message to ensure subscription is working
+    const msg1 = try sub.nextMsg(1000);
+    defer msg1.deinit();
+    try std.testing.expectEqualStrings("message 1", msg1.data);
+
+    // Start draining the subscription
+    try std.testing.expect(!sub.isDraining());
+    sub.drain(5000);
+    try std.testing.expect(sub.isDraining());
+
+    // Send messages after drain - these should be dropped
+    try conn.publish("test.drain", "message 2");
+    try conn.publish("test.drain", "message 3");
+    try conn.flush();
+
+    // Wait a bit to ensure messages would have arrived if not draining
+    std.time.sleep(100 * std.time.ns_per_ms);
+
+    // Try to receive - should timeout since new messages are dropped during drain
+    const result = sub.nextMsg(500);
+    try std.testing.expectError(error.Timeout, result);
+}
+
+const DrainMessageCounter = struct {
+    count: u32 = 0,
+    mutex: std.Thread.Mutex = .{},
+
+    pub fn processMsg(msg: *Message, self: *@This()) !void {
+        defer msg.deinit();
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.count += 1;
+        log.debug("DrainMessageCounter received message #{d}: {s}", .{ self.count, msg.data });
+    }
+
+    pub fn getCount(self: *@This()) u32 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.count;
+    }
+};
+
+test "async subscription drain functionality" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var counter: DrainMessageCounter = .{};
+
+    const sub = try conn.subscribe("test.async.drain", DrainMessageCounter.processMsg, .{&counter});
+    defer sub.deinit();
+
+    // Send a message before draining
+    try conn.publish("test.async.drain", "async message 1");
+    try conn.flush();
+
+    // Wait for the first message to be processed
+    var attempts: u32 = 0;
+    while (counter.getCount() == 0 and attempts < 100) {
+        std.time.sleep(10 * std.time.ns_per_ms);
+        attempts += 1;
+    }
+    try std.testing.expect(counter.getCount() == 1);
+
+    // Start draining
+    try std.testing.expect(!sub.isDraining());
+    sub.drain(5000);
+    try std.testing.expect(sub.isDraining());
+
+    // Send messages after drain - these should be dropped
+    try conn.publish("test.async.drain", "async message 2");
+    try conn.publish("test.async.drain", "async message 3");
+    try conn.flush();
+
+    // Wait to ensure messages would have arrived if not draining
+    std.time.sleep(200 * std.time.ns_per_ms);
+
+    // Count should still be 1 since new messages are dropped during drain
+    try std.testing.expect(counter.getCount() == 1);
+}


### PR DESCRIPTION
Implements Phase 1 of the drain functionality as outlined in issue #76.

## Changes
- Add drain state fields to Subscription struct
- Implement drain() and isDraining() methods
- Update Connection.processMsg() to drop messages for draining subscriptions
- Add comprehensive tests for both sync and async subscription drain
- All existing tests continue to pass (109/109)

## Implementation Notes
- Follows NATS drain semantics: stop accepting new messages while processing existing queue
- Thread-safe implementation works with both sync and async patterns
- Sends UNSUB to server and respects NATS protocol requirements

Fixes #76 (Phase 1)

