### PR TITLE
Implement autounsubscribe functionality for subscriptions

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1675,9 +1675,8 @@ pub const Connection = struct {
                 if (delivered < max) {
                     adjusted_max = max - delivered; // Remaining messages
                 } else {
-                    // Already reached limit - send UNSUB only
-                    try buffer.writer().print("UNSUB {d}\r\n", .{sub.sid});
-                    log.debug("Subscription {d} ({s}) already reached limit, sending UNSUB during reconnect", .{ sub.sid, sub.subject });
+                    // Already reached limit - don't re-subscribe at all
+                    log.debug("Subscription {d} ({s}) already reached limit, skipping during reconnect", .{ sub.sid, sub.subject });
                     continue;
                 }
             }

--- a/src/dispatcher.zig
+++ b/src/dispatcher.zig
@@ -147,11 +147,10 @@ pub const Dispatcher = struct {
         }
 
         // Check autounsubscribe limit after successful message delivery
-        if (subscription.max_msgs) |max| {
-            if (delivered >= max) {
-                log.debug("Subscription {} reached autounsubscribe limit ({}), removing", .{ subscription.sid, max });
-                subscription.nc.removeSubscriptionInternal(subscription.sid);
-            }
+        const max = subscription.max_msgs.load(.acquire);
+        if (max > 0 and delivered >= max) {
+            log.debug("Subscription {} reached autounsubscribe limit ({}), removing", .{ subscription.sid, max });
+            subscription.nc.removeSubscriptionInternal(subscription.sid);
         }
 
         // Decrement pending counters after handler completes (success or failure)

--- a/src/dispatcher.zig
+++ b/src/dispatcher.zig
@@ -130,6 +130,9 @@ pub const Dispatcher = struct {
         // Save message data length before handler is called (handler may deinit the message)
         const message_data_len = message.data.len;
 
+        // Increment delivered counter for autounsubscribe
+        const delivered = subscription.delivered_msgs.fetchAdd(1, .acq_rel) + 1;
+
         // Call the subscription's handler in this dispatcher thread context
         // Message ownership is transferred to the handler - handler is responsible for cleanup
         if (subscription.handler) |handler| {
@@ -141,6 +144,14 @@ pub const Dispatcher = struct {
             // No handler - this shouldn't happen for async subscriptions
             log.warn("Received message for subscription {} without handler", .{subscription.sid});
             message.deinit(); // Clean up orphaned message (no handler to transfer ownership to)
+        }
+
+        // Check autounsubscribe limit after successful message delivery
+        if (subscription.max_msgs) |max| {
+            if (delivered >= max) {
+                log.debug("Subscription {} reached autounsubscribe limit ({}), removing", .{ subscription.sid, max });
+                subscription.nc.removeSubscriptionInternal(subscription.sid);
+            }
         }
 
         // Decrement pending counters after handler completes (success or failure)

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -181,6 +181,8 @@ pub const Subscription = struct {
         SendFailed,
     };
 
+    /// Issues an automatic unsubscribe that is processed by the server when 'max' messages have been received.
+    /// This can be useful when sending a request to an unknown number of subscribers.
     pub fn autoUnsubscribe(self: *Subscription, max: u64) AutoUnsubscribeError!void {
         if (max == 0) return AutoUnsubscribeError.InvalidMax;
 

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -146,7 +146,11 @@ pub const Subscription = struct {
         if (prev_state != null) return; // Already draining
 
         // Send UNSUB to server
-        self.nc.unsubscribeInternal(self.sid);
+        self.nc.unsubscribeInternal(self.sid, null) catch |err| {
+            // Even with this failing, once we set draining to true,
+            // messages will be dropped, so it's OK to continue
+            log.err("Failed to send UNSUB for sid {d}: {}", .{ self.sid, err });
+        };
     }
 
     pub fn isDraining(self: *Subscription) bool {

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -7,6 +7,7 @@ test {
     _ = @import("minimal_test.zig");
     _ = @import("headers_test.zig");
     _ = @import("subscribe_test.zig");
+    _ = @import("autounsubscribe_test.zig");
     _ = @import("pending_msgs_test.zig");
     _ = @import("drain_test.zig");
     _ = @import("core_request_reply_test.zig");

--- a/tests/autounsubscribe_test.zig
+++ b/tests/autounsubscribe_test.zig
@@ -1,0 +1,140 @@
+const std = @import("std");
+const nats = @import("nats");
+const utils = @import("utils.zig");
+const Message = nats.Message;
+
+test "autounsubscribe sync basic functionality" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("auto.test");
+    defer sub.deinit();
+
+    // Set autounsubscribe limit to 3 messages
+    try sub.autoUnsubscribe(3);
+
+    // Publish 5 messages
+    for (0..5) |i| {
+        var buf: [32]u8 = undefined;
+        const msg_data = try std.fmt.bufPrint(&buf, "message_{d}", .{i});
+        try conn.publish("auto.test", msg_data);
+    }
+    try conn.flush();
+
+    // Should receive exactly 3 messages
+    var received_count: u32 = 0;
+    for (0..3) |_| {
+        const msg = try sub.nextMsg(1000);
+        defer msg.deinit();
+        received_count += 1;
+    }
+
+    try std.testing.expectEqual(@as(u32, 3), received_count);
+
+    // Fourth message should timeout (subscription auto-unsubscribed)
+    try std.testing.expectError(error.Timeout, sub.nextMsg(100));
+}
+
+test "autounsubscribe async basic functionality" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    var messages_received = std.ArrayList(*Message).init(std.testing.allocator);
+    defer {
+        for (messages_received.items) |msg| {
+            msg.deinit();
+        }
+        messages_received.deinit();
+    }
+
+    const TestContext = struct {
+        messages: *std.ArrayList(*Message),
+        mutex: std.Thread.Mutex = .{},
+
+        pub fn handleMessage(msg: *Message, self: *@This()) !void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            try self.messages.append(msg);
+        }
+    };
+
+    var ctx = TestContext{ .messages = &messages_received };
+
+    const sub = try conn.subscribe("auto.async.test", TestContext.handleMessage, .{&ctx});
+    defer sub.deinit();
+
+    // Set autounsubscribe limit to 2 messages
+    try sub.autoUnsubscribe(2);
+
+    // Publish 4 messages
+    for (0..4) |i| {
+        var buf: [32]u8 = undefined;
+        const msg_data = try std.fmt.bufPrint(&buf, "async_message_{d}", .{i});
+        try conn.publish("auto.async.test", msg_data);
+    }
+    try conn.flush();
+
+    // Wait a bit for message processing
+    std.time.sleep(100 * std.time.ns_per_ms);
+
+    // Should have received exactly 2 messages
+    ctx.mutex.lock();
+    const count = messages_received.items.len;
+    ctx.mutex.unlock();
+
+    try std.testing.expectEqual(@as(usize, 2), count);
+}
+
+test "autounsubscribe error conditions" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("error.test");
+    defer sub.deinit();
+
+    // Test invalid max (zero)
+    try std.testing.expectError(error.InvalidMax, sub.autoUnsubscribe(0));
+
+    // Publish and receive a message first
+    try conn.publish("error.test", "first message");
+    try conn.flush();
+
+    const msg = try sub.nextMsg(1000);
+    defer msg.deinit();
+
+    // Now try to set autounsubscribe to 1 (should fail since we already received 1)
+    try std.testing.expectError(error.MaxAlreadyReached, sub.autoUnsubscribe(1));
+}
+
+test "autounsubscribe delivered message counter" {
+    var conn = try utils.createDefaultConnection();
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("counter.test");
+    defer sub.deinit();
+
+    try sub.autoUnsubscribe(2);
+
+    // Verify initial state
+    try std.testing.expectEqual(@as(u64, 0), sub.delivered_msgs.load(.monotonic));
+
+    // Publish messages and verify counter increments correctly
+    try conn.publish("counter.test", "message 1");
+    try conn.flush();
+
+    const msg1 = try sub.nextMsg(1000);
+    defer msg1.deinit();
+    try std.testing.expectEqual(@as(u64, 1), sub.delivered_msgs.load(.monotonic));
+
+    try conn.publish("counter.test", "message 2");
+    try conn.flush();
+
+    const msg2 = try sub.nextMsg(1000);
+    defer msg2.deinit();
+    try std.testing.expectEqual(@as(u64, 2), sub.delivered_msgs.load(.monotonic));
+
+    // Third message should timeout due to autounsubscribe
+    try conn.publish("counter.test", "message 3");
+    try conn.flush();
+    try std.testing.expectError(error.Timeout, sub.nextMsg(100));
+}


### PR DESCRIPTION
Add automatic unsubscription capability that removes subscriptions after receiving a specified maximum number of messages. This feature is essential for request-response patterns and resource management.

Key features:
- Atomic message delivery counting with proper memory ordering
- Protocol-compliant UNSUB commands with message limits
- Comprehensive error handling with rollback on failure
- Support for both sync and async subscription types
- Thread-safe subscription removal from connection state

The implementation follows NATS protocol standards and includes extensive test coverage for all functionality and edge cases.