### PR TITLE
Export nuid module from root.zig

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -29,6 +29,7 @@ pub const ServerPool = @import("server_pool.zig").ServerPool;
 pub const Server = @import("server_pool.zig").Server;
 pub const Socket = @import("socket.zig").Socket;
 pub const inbox = @import("inbox.zig");
+pub const nuid = @import("nuid.zig");
 
 // JetStream types
 pub const JetStream = @import("jetstream.zig").JetStream;


### PR DESCRIPTION
## Summary
- Export the nuid module from root.zig to make it available to library users

## Test plan
- Verify the module exports correctly and can be imported by users