### PR TITLE
Fix flaky JetStream publish test in clustered environments

### DIFF
--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -1576,6 +1576,12 @@ pub const JetStream = struct {
         }
 
         // Send request without retry logic
+        // TODO: Implement retry logic for NoResponders (503) errors in clustered environments
+        // See ADR-22: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-22.md
+        // Reference implementations:
+        // - nats.go: 250ms backoff, 2 retries by default
+        // - nats.c: Check their implementation
+        // - nats.java: Check their implementation
         const resp = self.nc.requestMsg(msg, self.opts.request_timeout_ms) catch |request_err| {
             return if (request_err == error.NoResponders) error.NoStreamResponse else request_err;
         };

--- a/tests/jetstream_test.zig
+++ b/tests/jetstream_test.zig
@@ -706,6 +706,10 @@ test "JetStream publish basic message" {
     var stream_info = try js.addStream(stream_config);
     defer stream_info.deinit();
 
+    // Wait for stream metadata to propagate across cluster nodes
+    // TODO: Remove this delay once retry logic is implemented (see ADR-22)
+    try rt.sleep(.fromMilliseconds(100));
+
     // Publish a message using JetStream publish
     const test_data = "Hello JetStream!";
     var pub_ack = try js.publish(subject, test_data, .{});


### PR DESCRIPTION
## Summary

Fixes a timing race condition in the "JetStream publish basic message" test that was causing intermittent CI failures with `NoStreamResponse` errors.

## Root Cause

In NATS clustered environments, when a stream is created, there's a brief propagation window before all cluster nodes are aware of the new stream. If a client publishes immediately after stream creation to a node that hasn't received the metadata yet, it receives a 503 No Responders error.

## Changes

- Added 100ms delay in `jetstream_test.zig` after stream creation to allow cluster metadata propagation
- Added TODO comments in `jetstream.zig` for implementing proper retry logic per ADR-22
- Referenced nats.go's approach (250ms backoff, 2 retries by default)

## Test Plan

- Existing test should now pass reliably in CI
- Delay matches pattern used in other JetStream tests (push, nak, etc.)
- Full retry logic implementation tracked for future work