### PR TITLE
Migrate synchronization primitives to std.Io via xsync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: 0.15.2
+        version: 0.16.0
 
     - name: Install libnats
       run: sudo apt-get update && sudo apt-get install libnats-dev

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /_refs
 /zig-out
 /.zig-cache
+/zig-pkg

--- a/benchmarks/bench_util.zig
+++ b/benchmarks/bench_util.zig
@@ -17,7 +17,7 @@ pub const BenchStats = struct {
     last_report_time: i128 = 0,
 
     pub fn init() BenchStats {
-        const now = std.time.nanoTimestamp();
+        const now = zio.Timestamp.now(.monotonic).toNanoseconds();
         return BenchStats{
             .start_time = now,
             .last_report_time = now,
@@ -26,7 +26,7 @@ pub const BenchStats = struct {
 
     pub fn elapsedS(self: *const BenchStats, start_time: i128) f64 {
         _ = self;
-        const now = std.time.nanoTimestamp();
+        const now = zio.Timestamp.now(.monotonic).toNanoseconds();
         const elapsed_ns = now - start_time;
         return @as(f64, @floatFromInt(elapsed_ns)) / std.time.ns_per_s;
     }
@@ -47,7 +47,7 @@ pub const BenchStats = struct {
         self.last_msg_count = self.msg_count;
         self.last_success_count = self.success_count;
         self.last_error_count = self.error_count;
-        self.last_report_time = std.time.nanoTimestamp();
+        self.last_report_time = zio.Timestamp.now(.monotonic).toNanoseconds();
     }
 
     pub fn printError(self: *BenchStats, err: anyerror) void {
@@ -73,7 +73,7 @@ pub const BenchStats = struct {
     }
 };
 
-fn benchSignalHandler(sig_num: i32) callconv(.c) void {
+fn benchSignalHandler(sig_num: std.posix.SIG) callconv(.c) void {
     _ = sig_num;
     keep_running = false;
 }
@@ -98,7 +98,7 @@ pub fn connect(allocator: std.mem.Allocator, url: ?[]const u8) !*nats.Connection
     var conn = try allocator.create(nats.Connection);
     errdefer allocator.destroy(conn);
 
-    conn.* = nats.Connection.init(allocator, .{});
+    conn.* = nats.Connection.init(allocator, rt.io(), .{});
 
     const connect_url = url orelse "nats://localhost:4222";
     conn.connect(connect_url) catch |err| {

--- a/benchmarks/echo_client.zig
+++ b/benchmarks/echo_client.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const nats = @import("nats");
+const zio = @import("zio");
 const bench_util = @import("bench_util.zig");
 
 const REPORT_INTERVAL = 1000;
@@ -10,7 +11,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -63,7 +64,7 @@ pub fn main() !void {
             stats.last_msg_count = stats.msg_count;
             stats.last_success_count = stats.success_count;
             stats.last_error_count = stats.error_count;
-            stats.last_report_time = std.time.nanoTimestamp();
+            stats.last_report_time = zio.Timestamp.now(.monotonic).toNanoseconds();
         }
     }
 

--- a/benchmarks/echo_server.zig
+++ b/benchmarks/echo_server.zig
@@ -9,7 +9,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/benchmarks/publisher.zig
+++ b/benchmarks/publisher.zig
@@ -9,7 +9,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/benchmarks/subscriber.zig
+++ b/benchmarks/subscriber.zig
@@ -9,7 +9,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
     // Parse the ZON content at compile time, or use fallback values if parsing fails
     var parsed_zon: BuildZon = undefined;
     var should_free = false;
-    if (std.zon.parse.fromSlice(BuildZon, b.allocator, zon_content, null, .{})) |result| {
+    if (std.zon.parse.fromSliceAlloc(BuildZon, b.allocator, zon_content, null, .{})) |result| {
         parsed_zon = result;
         should_free = true;
     } else |_| {
@@ -35,6 +35,11 @@ pub fn build(b: *std.Build) void {
     defer if (should_free) std.zon.parse.free(b.allocator, parsed_zon);
 
     const zio = b.dependency("zio", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const xsync = b.dependency("xsync", .{
         .target = target,
         .optimize = optimize,
     });
@@ -58,6 +63,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     lib_mod.addImport("zio", zio.module("zio"));
+    lib_mod.addImport("xsync", xsync.module("xsync"));
 
     // Add build options to the module
     lib_mod.addOptions("build_options", options);
@@ -176,12 +182,12 @@ pub fn build(b: *std.Build) void {
             .root_source_file = null,
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
-    c_echo_server.addCSourceFile(.{ .file = b.path("benchmarks/echo_server.c"), .flags = &.{} });
-    c_echo_server.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
-    c_echo_server.linkLibC();
-    c_echo_server.linkSystemLibrary("nats");
+    c_echo_server.root_module.addCSourceFile(.{ .file = b.path("benchmarks/echo_server.c"), .flags = &.{} });
+    c_echo_server.root_module.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
+    c_echo_server.root_module.linkSystemLibrary("nats", .{});
 
     const c_echo_client = b.addExecutable(.{
         .name = "echo_client_c",
@@ -189,12 +195,12 @@ pub fn build(b: *std.Build) void {
             .root_source_file = null,
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
-    c_echo_client.addCSourceFile(.{ .file = b.path("benchmarks/echo_client.c"), .flags = &.{} });
-    c_echo_client.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
-    c_echo_client.linkLibC();
-    c_echo_client.linkSystemLibrary("nats");
+    c_echo_client.root_module.addCSourceFile(.{ .file = b.path("benchmarks/echo_client.c"), .flags = &.{} });
+    c_echo_client.root_module.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
+    c_echo_client.root_module.linkSystemLibrary("nats", .{});
 
     const c_publisher = b.addExecutable(.{
         .name = "publisher_c",
@@ -202,12 +208,12 @@ pub fn build(b: *std.Build) void {
             .root_source_file = null,
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
-    c_publisher.addCSourceFile(.{ .file = b.path("benchmarks/publisher.c"), .flags = &.{} });
-    c_publisher.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
-    c_publisher.linkLibC();
-    c_publisher.linkSystemLibrary("nats");
+    c_publisher.root_module.addCSourceFile(.{ .file = b.path("benchmarks/publisher.c"), .flags = &.{} });
+    c_publisher.root_module.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
+    c_publisher.root_module.linkSystemLibrary("nats", .{});
 
     const c_subscriber = b.addExecutable(.{
         .name = "subscriber_c",
@@ -215,12 +221,12 @@ pub fn build(b: *std.Build) void {
             .root_source_file = null,
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
-    c_subscriber.addCSourceFile(.{ .file = b.path("benchmarks/subscriber.c"), .flags = &.{} });
-    c_subscriber.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
-    c_subscriber.linkLibC();
-    c_subscriber.linkSystemLibrary("nats");
+    c_subscriber.root_module.addCSourceFile(.{ .file = b.path("benchmarks/subscriber.c"), .flags = &.{} });
+    c_subscriber.root_module.addCSourceFile(.{ .file = b.path("benchmarks/bench_util.c"), .flags = &.{} });
+    c_subscriber.root_module.linkSystemLibrary("nats", .{});
 
     const install_c_echo_server = b.addInstallArtifact(c_echo_server, .{});
     const install_c_echo_client = b.addInstallArtifact(c_echo_client, .{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
@@ -37,8 +37,12 @@
     // internet connectivity.
     .dependencies = .{
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio?ref=v0.8.2#3ac234eae165177cd75742f922851dc5d373fd12",
-            .hash = "zio-0.8.2-xHbVVC5jGAAYUMZd_BW5eT-HJb_lf-LCGj4PaLOeEkA2",
+            .url = "git+https://github.com/lalinsky/zio#175ca4833c2a20f52ee023b97589336bc508d464",
+            .hash = "zio-0.17.0-xHbVVJ4LJwCysqAz5HnmE8QoT2-W4iI-dMFucTYmldrp",
+        },
+        .xsync = .{
+            .url = "git+https://github.com/lalinsky/xsync.zig?ref=v1.0.0#2ab0801071f1918d799c115542b8121486dc2520",
+            .hash = "xsync-1.0.0-CcXcL3DCAQA0FPLdBPhtTB182kN-COorlMw_cabmgHJm",
         },
     },
     .paths = .{

--- a/examples/pub.zig
+++ b/examples/pub.zig
@@ -4,7 +4,7 @@ const nats = @import("nats");
 const zio = @import("zio");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -15,7 +15,7 @@ pub fn main() !void {
     defer rt.deinit();
 
     // Connect to NATS server
-    var conn = nats.Connection.init(allocator, .{});
+    var conn = nats.Connection.init(allocator, rt.io(), .{});
     defer conn.deinit();
 
     try conn.connect("nats://localhost:4222");

--- a/examples/replier.zig
+++ b/examples/replier.zig
@@ -3,7 +3,7 @@ const nats = @import("nats");
 const zio = @import("zio");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -14,7 +14,7 @@ pub fn main() !void {
     defer rt.deinit();
 
     // Creates a connection to the default NATS URL
-    var conn = nats.Connection.init(allocator, .{});
+    var conn = nats.Connection.init(allocator, rt.io(), .{});
     defer conn.deinit();
 
     conn.connect("nats://localhost:4222") catch |err| {

--- a/examples/requestor.zig
+++ b/examples/requestor.zig
@@ -3,7 +3,7 @@ const nats = @import("nats");
 const zio = @import("zio");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -14,7 +14,7 @@ pub fn main() !void {
     defer rt.deinit();
 
     // Creates a connection to the default NATS URL
-    var conn = nats.Connection.init(allocator, .{});
+    var conn = nats.Connection.init(allocator, rt.io(), .{});
     defer conn.deinit();
 
     conn.connect("nats://localhost:4222") catch |err| {

--- a/examples/sub.zig
+++ b/examples/sub.zig
@@ -4,7 +4,7 @@ const nats = @import("nats");
 const zio = @import("zio");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -15,7 +15,7 @@ pub fn main() !void {
     defer rt.deinit();
 
     // Connect to NATS server
-    var conn = nats.Connection.init(allocator, .{});
+    var conn = nats.Connection.init(allocator, rt.io(), .{});
     defer conn.deinit();
 
     try conn.connect("nats://localhost:4222");

--- a/examples/sub_async.zig
+++ b/examples/sub_async.zig
@@ -11,7 +11,7 @@ fn messageHandler(msg: *nats.Message, counter: *u32, prefix: []const u8) void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -22,7 +22,7 @@ pub fn main() !void {
     defer rt.deinit();
 
     // Connect to NATS server
-    var conn = nats.Connection.init(allocator, .{});
+    var conn = nats.Connection.init(allocator, rt.io(), .{});
     defer conn.deinit();
 
     try conn.connect("nats://localhost:4222");
@@ -38,7 +38,7 @@ pub fn main() !void {
     std.log.info("Subscribed with callback handler. Waiting for messages (10 seconds)...", .{});
 
     // Keep the program running to receive messages
-    std.Thread.sleep(10 * std.time.ns_per_s);
+    zio.sleep(.fromSeconds(10)) catch {};
 
     std.log.info("Shutting down after receiving {} messages", .{counter});
 }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -34,6 +34,11 @@ const ResponseManager = @import("response_manager.zig").ResponseManager;
 const MAX_CONTROL_LINE_SIZE = @import("parser.zig").MAX_CONTROL_LINE_SIZE;
 const validation = @import("validation.zig");
 const zio = @import("zio");
+const xsync = @import("xsync");
+const Io = std.Io;
+const io_util = @import("io_util.zig");
+const nsTimeout = io_util.nsTimeout;
+const msTimeout = io_util.msTimeout;
 
 const log = @import("log.zig").log;
 
@@ -114,7 +119,7 @@ pub const ConnectionError = error{
     NotConnected,
     ManualReconnect,
     StaleConnection,
-} || PublishError || ProtocolError || std.Thread.SpawnError || std.posix.WriteError || std.posix.ReadError;
+} || PublishError || ProtocolError || std.Thread.SpawnError || zio.ev.NetRecv.Error || zio.ev.NetSend.Error;
 
 // Protocol-specific errors from server -ERR messages (matching nats.go approach)
 pub const ProtocolError = error{
@@ -230,10 +235,13 @@ pub const ConnectionOptions = struct {
 pub const Connection = struct {
     allocator: Allocator,
 
+    /// The `std.Io` instance used for blocking and waking
+    io: Io,
+
     options: ConnectionOptions,
 
     status: ConnectionStatus = .closed,
-    status_cond: zio.Condition = .{},
+    status_cond: xsync.Condition = .init,
 
     reconnect_requested: zio.ResetEvent = .{},
 
@@ -249,21 +257,21 @@ pub const Connection = struct {
     // Handshake state
     handshake_state: HandshakeState = .not_started,
     handshake_error: ?anyerror = null,
-    handshake_cond: zio.Condition = .{},
+    handshake_cond: xsync.Condition = .init,
 
     // Connection manager fiber (owns reader/flusher tasks)
     manager_task: zio.Group = .init,
 
     // Main connection mutex (protects most fields)
-    mutex: zio.Mutex = .{},
+    mutex: xsync.Mutex = .init,
 
     // PING/PONG flush tracking (simplified counter approach)
     outgoing_pings: u64 = 0,
     incoming_pongs: u64 = 0,
-    pong_condition: zio.Condition = .{},
+    pong_condition: xsync.Condition = .init,
 
     // PING/PONG keep-alive tracking
-    ping_timer: std.time.Timer, // Timer for tracking ping intervals
+    ping_timer: zio.Stopwatch, // Timer for tracking ping intervals
     pings_out: std.atomic.Value(u32) = std.atomic.Value(u32).init(0), // Outstanding keep-alive pings (atomic)
 
     // Write buffer (thread-safe, 64KB chunk size)
@@ -272,14 +280,14 @@ pub const Connection = struct {
     // Subscriptions
     next_sid: std.atomic.Value(u64) = std.atomic.Value(u64).init(1),
     subscriptions: std.AutoHashMap(u64, *Subscription),
-    subs_mutex: zio.Mutex = .{},
+    subs_mutex: xsync.Mutex = .init,
 
     // Response management (shared subscription for request/reply)
     response_manager: ResponseManager,
 
     // Connection draining
     drain_state: std.atomic.Value(DrainState) = std.atomic.Value(DrainState).init(.not_draining),
-    drain_completion: zio.ResetEvent = .init,
+    drain_completion: xsync.Event = .init,
     drain_subscription_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     drain_ping_id: u64 = 0,
 
@@ -291,20 +299,21 @@ pub const Connection = struct {
     const Self = @This();
     const WriteBuffer = ConcurrentWriteBuffer(65536); // 64KB chunk size
 
-    pub fn init(allocator: Allocator, options: ConnectionOptions) Self {
+    pub fn init(allocator: Allocator, io: Io, options: ConnectionOptions) Self {
         return Self{
             .allocator = allocator,
+            .io = io,
 
             .options = options,
             .server_pool = ServerPool.init(allocator),
             .server_info_arena = std.heap.ArenaAllocator.init(allocator),
-            .pending_buffer = WriteBuffer.init(allocator, .{ .max_size = options.reconnect.reconnect_buf_size }),
-            .write_buffer = WriteBuffer.init(allocator, .{}),
+            .pending_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.reconnect.reconnect_buf_size }),
+            .write_buffer = WriteBuffer.init(allocator, io, .{}),
             .subscriptions = std.AutoHashMap(u64, *Subscription).init(allocator),
-            .response_manager = ResponseManager.init(allocator),
-            .parser = Parser.init(allocator),
+            .response_manager = ResponseManager.init(allocator, io),
+            .parser = Parser.init(allocator, io),
             .scratch = std.heap.ArenaAllocator.init(allocator),
-            .ping_timer = std.time.Timer.start() catch unreachable,
+            .ping_timer = zio.Stopwatch.start(),
         };
     }
 
@@ -346,8 +355,8 @@ pub const Connection = struct {
     pub fn connect(self: *Self, url: []const u8) !void {
         errdefer self.close();
 
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.status != .closed) {
             log.err("Already connected", .{});
@@ -355,7 +364,7 @@ pub const Connection = struct {
         }
 
         self.status = .connecting;
-        self.status_cond.broadcast();
+        self.status_cond.broadcast(self.io);
 
         _ = try self.server_pool.addServer(url, false);
 
@@ -378,15 +387,15 @@ pub const Connection = struct {
                     return;
                 },
                 else => {
-                    try self.status_cond.wait(&self.mutex);
+                    try self.status_cond.wait(self.io, &self.mutex);
                 },
             }
         }
     }
 
     pub fn addServer(self: *Self, url: []const u8) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         _ = try self.server_pool.addServer(url, false);
     }
@@ -401,8 +410,8 @@ pub const Connection = struct {
 
         self.manager_task.cancel();
 
-        self.mutex.lockUncancelable();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.status == .closed) {
             return;
@@ -410,14 +419,14 @@ pub const Connection = struct {
 
         // Mark the connection as permanently closed
         self.status = .closed;
-        self.status_cond.broadcast();
+        self.status_cond.broadcast(self.io);
 
         // Close write buffers to wake up any waiting fibers
         self.pending_buffer.close();
         self.write_buffer.close();
 
         // Wake up any waiting flush() calls
-        self.pong_condition.broadcast();
+        self.pong_condition.broadcast(self.io);
 
         // Make sure we invoke the closed callback
         if (self.options.callbacks.closed_cb) |cb| {
@@ -426,8 +435,8 @@ pub const Connection = struct {
     }
 
     pub fn getStatus(self: *Self) ConnectionStatus {
-        self.mutex.lockUncancelable();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         return self.status;
     }
 
@@ -447,8 +456,8 @@ pub const Connection = struct {
     /// - Testing reconnection behavior
     /// Returns error if reconnection cannot be initiated
     pub fn reconnect(self: *Self) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         // Check if reconnection is allowed
         if (!self.options.reconnect.allow_reconnect) {
@@ -527,17 +536,18 @@ pub const Connection = struct {
             return error.DrainInProgress;
         }
 
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         const allocator = self.scratch.allocator();
         defer self.resetScratch();
 
-        var headers_buffer = ArrayList(u8){};
-        defer headers_buffer.deinit(allocator);
+        var headers_buffer: std.Io.Writer.Allocating = .init(allocator);
+        defer headers_buffer.deinit();
 
-        try msg.encodeHeaders(headers_buffer.writer(allocator));
-        const headers_len = headers_buffer.items.len;
+        try msg.encodeHeaders(&headers_buffer.writer);
+        const headers = headers_buffer.written();
+        const headers_len = headers.len;
 
         const total_payload = headers_len + msg.data.len;
 
@@ -548,10 +558,10 @@ pub const Connection = struct {
         const reply_to_use = reply_override orelse msg.reply;
 
         // Build control line + headers (without copying msg.data)
-        var buffer = try std.ArrayListUnmanaged(u8).initCapacity(allocator, MAX_CONTROL_LINE_SIZE + headers_len);
-        defer buffer.deinit(allocator);
+        const control_buf = try allocator.alloc(u8, MAX_CONTROL_LINE_SIZE + headers_len);
+        defer allocator.free(control_buf);
 
-        var buffer_writer = buffer.fixedWriter();
+        var buffer_writer = std.Io.Writer.fixed(control_buf);
 
         if (headers_len > 0) {
             // HPUB <subject> [reply] <headers_len> <total_len>\r\n<headers>
@@ -560,7 +570,7 @@ pub const Connection = struct {
             } else {
                 try buffer_writer.print("HPUB {s} {d} {d}\r\n", .{ msg.subject, headers_len, total_payload });
             }
-            try buffer_writer.writeAll(headers_buffer.items);
+            try buffer_writer.writeAll(headers);
         } else {
             // PUB <subject> [reply] <size>\r\n
             if (reply_to_use) |reply| {
@@ -580,7 +590,7 @@ pub const Connection = struct {
         }
 
         // Append control+headers, data, and trailer without copying msg.data
-        const slices = &[_][]const u8{ buffer.items, msg.data, "\r\n" };
+        const slices = &[_][]const u8{ buffer_writer.buffered(), msg.data, "\r\n" };
 
         // Published messages go to pending_buffer during reconnection, otherwise write_buffer
         if (self.status == .reconnecting and self.options.reconnect.allow_reconnect) {
@@ -597,15 +607,15 @@ pub const Connection = struct {
     }
 
     fn subscribeInternal(self: *Self, sub: *Subscription) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.status != .connected) {
             return ConnectionError.ConnectionClosed;
         }
 
-        try self.subs_mutex.lock();
-        defer self.subs_mutex.unlock();
+        try self.subs_mutex.lock(self.io);
+        defer self.subs_mutex.unlock(self.io);
 
         try self.subscriptions.put(sub.sid, sub);
         errdefer _ = self.subscriptions.remove(sub.sid);
@@ -614,14 +624,14 @@ pub const Connection = struct {
         const allocator = self.scratch.allocator();
         defer self.resetScratch();
 
-        var buffer = ArrayList(u8){};
-        defer buffer.deinit(allocator);
+        var buffer: std.Io.Writer.Allocating = .init(allocator);
+        defer buffer.deinit();
         if (sub.queue) |group| {
-            try buffer.writer(allocator).print("SUB {s} {s} {d}\r\n", .{ sub.subject, group, sub.sid });
+            try buffer.writer.print("SUB {s} {s} {d}\r\n", .{ sub.subject, group, sub.sid });
         } else {
-            try buffer.writer(allocator).print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
+            try buffer.writer.print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
         }
-        try self.write_buffer.append(buffer.items);
+        try self.write_buffer.append(buffer.written());
     }
 
     pub fn subscribe(self: *Self, subject: []const u8, comptime handlerFn: anytype, args: anytype) !*Subscription {
@@ -690,8 +700,7 @@ pub const Connection = struct {
 
     pub fn unsubscribeInternal(self: *Self, sid: u64, max: ?u64) !void {
         var buffer: [256]u8 = undefined;
-        var stream = std.io.fixedBufferStream(&buffer);
-        var writer = stream.writer();
+        var writer = std.Io.Writer.fixed(&buffer);
 
         if (max) |m| {
             writer.print("UNSUB {d} {d}\r\n", .{ sid, m }) catch unreachable; // Will always fit
@@ -699,17 +708,17 @@ pub const Connection = struct {
             writer.print("UNSUB {d}\r\n", .{sid}) catch unreachable; // Will always fit
         }
 
-        try self.write_buffer.append(stream.getWritten());
+        try self.write_buffer.append(writer.buffered());
     }
 
     pub fn unsubscribe(self: *Self, sub: *Subscription) void {
         // Remove from subscription table first
         {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
-            self.subs_mutex.lockUncancelable();
-            defer self.subs_mutex.unlock();
+            self.subs_mutex.lockUncancelable(self.io);
+            defer self.subs_mutex.unlock(self.io);
 
             if (!self.subscriptions.remove(sub.sid)) {
                 // Nothing to do, already unsubscribed
@@ -733,8 +742,8 @@ pub const Connection = struct {
     /// Remove subscription from connection's subscription table
     /// This does not send UNSUB to server - that should be done separately
     pub fn removeSubscriptionInternal(self: *Self, sid: u64) void {
-        self.subs_mutex.lockUncancelable();
-        defer self.subs_mutex.unlock();
+        self.subs_mutex.lockUncancelable(self.io);
+        defer self.subs_mutex.unlock(self.io);
 
         if (self.subscriptions.fetchRemove(sid)) |kv| {
             log.debug("Removed subscription {d} ({s}) from connection", .{ sid, kv.value.subject });
@@ -744,15 +753,15 @@ pub const Connection = struct {
     }
 
     pub fn flush(self: *Self) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         while (self.status != .connected) {
             if (self.status == .closed) {
                 log.debug("Flush skipped, no longer connected", .{});
                 return error.ConnectionClosed;
             }
-            try self.status_cond.wait(&self.mutex);
+            try self.status_cond.wait(self.io, &self.mutex);
         }
 
         const our_ping_id = try self.sendPing(false);
@@ -760,7 +769,7 @@ pub const Connection = struct {
         log.debug("Sent PING with ping_id={}, waiting for PONG", .{our_ping_id});
 
         const timeout_ns = self.options.timeout_ms * std.time.ns_per_ms;
-        var timer = try std.time.Timer.start();
+        var timer = zio.Stopwatch.start();
 
         while (self.incoming_pongs < our_ping_id) {
             if (self.status != .connected) {
@@ -768,14 +777,14 @@ pub const Connection = struct {
                 return ConnectionError.ConnectionClosed;
             }
 
-            const elapsed_ns = timer.read();
+            const elapsed_ns = timer.read().toNanoseconds();
             if (elapsed_ns >= timeout_ns) {
                 log.warn("Flush timeout waiting for PONG", .{});
                 return ConnectionError.Timeout;
             }
 
             const remaining_ns = timeout_ns - elapsed_ns;
-            self.pong_condition.timedWait(&self.mutex, .fromNanoseconds(remaining_ns)) catch {};
+            self.pong_condition.waitTimeout(self.io, &self.mutex, nsTimeout(remaining_ns)) catch {};
         }
 
         log.debug("Flush completed, received PONG for ping_id={}", .{our_ping_id});
@@ -868,12 +877,12 @@ pub const Connection = struct {
         defer log.debug("Manager loop exited", .{});
 
         defer {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             if (self.status != .closed) {
                 self.status = .connection_failed;
-                self.status_cond.broadcast();
+                self.status_cond.broadcast(self.io);
             }
         }
 
@@ -892,8 +901,8 @@ pub const Connection = struct {
             var callback: @TypeOf(self.options.callbacks.disconnected_cb) = null;
             defer if (callback) |cb| cb(self);
 
-            try self.mutex.lock();
-            defer self.mutex.unlock();
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
 
             if (conn_err) |err| {
                 log.info("Connection failed: {}", .{err});
@@ -906,7 +915,7 @@ pub const Connection = struct {
             }
 
             self.status = .reconnecting;
-            self.status_cond.broadcast();
+            self.status_cond.broadcast(self.io);
 
             if (self.options.callbacks.disconnected_cb) |cb| {
                 callback = cb;
@@ -917,8 +926,8 @@ pub const Connection = struct {
     }
 
     fn selectNextServer(self: *Self) !*Server {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         const server = try self.server_pool.getNextServer(self.options.reconnect.max_reconnect, self.current_server) orelse return error.NoServerAvailable;
         server.reconnects += 1;
@@ -937,8 +946,8 @@ pub const Connection = struct {
             log.debug("Connected, starting handshake...", .{});
         }
 
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         std.debug.assert(self.status == .connecting or self.status == .reconnecting);
 
@@ -956,7 +965,7 @@ pub const Connection = struct {
         // Initialize handshake state
         self.handshake_state = .waiting_for_info;
         self.handshake_error = null;
-        self.handshake_cond.broadcast();
+        self.handshake_cond.broadcast(self.io);
 
         // Unfreeze write buffer now that we have a working socket
         self.write_buffer.unfreeze();
@@ -980,17 +989,17 @@ pub const Connection = struct {
 
         var was_reconnect = false;
 
-        try self.mutex.lock();
+        try self.mutex.lock(self.io);
         self.waitForHandshakeCompletion() catch |err| {
-            self.mutex.unlock();
+            self.mutex.unlock(self.io);
             return err;
         };
         if (self.status == .reconnecting) {
             was_reconnect = true;
         }
         self.status = .connected;
-        self.status_cond.broadcast();
-        self.mutex.unlock();
+        self.status_cond.broadcast(self.io);
+        self.mutex.unlock(self.io);
 
         log.info("Connected successfully to {s}", .{server.parsed_url.full_url});
 
@@ -1102,12 +1111,12 @@ pub const Connection = struct {
         defer if (owns_message) message.deinit();
 
         // Retain subscription while holding lock, then release lock
-        try self.subs_mutex.lock();
+        try self.subs_mutex.lock(self.io);
         const sub = self.subscriptions.get(message.sid);
         if (sub) |s| {
             s.retain(); // Keep subscription alive
         }
-        self.subs_mutex.unlock();
+        self.subs_mutex.unlock(self.io);
 
         if (sub) |s| {
             defer s.release(); // Release when done
@@ -1160,8 +1169,8 @@ pub const Connection = struct {
         defer self.resetScratch();
 
         // Build CONNECT message with all options
-        var buffer = ArrayList(u8){};
-        defer buffer.deinit(allocator);
+        var buffer: std.Io.Writer.Allocating = .init(allocator);
+        defer buffer.deinit();
 
         // Calculate effective no_responders: enable if server supports headers
         const no_responders = self.options.no_responders and self.server_info.headers;
@@ -1188,13 +1197,13 @@ pub const Connection = struct {
             .auth_token = auth_token,
         };
 
-        try buffer.writer(allocator).writeAll("CONNECT ");
-        try std.fmt.format(buffer.writer(allocator), "{f}", .{std.json.fmt(connect_obj, .{})});
-        try buffer.writer(allocator).writeAll("\r\n");
-        try buffer.writer(allocator).writeAll("PING\r\n");
+        try buffer.writer.writeAll("CONNECT ");
+        try buffer.writer.print("{f}", .{std.json.fmt(connect_obj, .{})});
+        try buffer.writer.writeAll("\r\n");
+        try buffer.writer.writeAll("PING\r\n");
 
         // Send via buffer (mutex already held)
-        try self.write_buffer.append(buffer.items);
+        try self.write_buffer.append(buffer.written());
 
         log.debug("Sent CONNECT+PING during handshake", .{});
     }
@@ -1202,8 +1211,8 @@ pub const Connection = struct {
     pub fn processInfo(self: *Self, info_json: []const u8) !void {
         log.debug("Received INFO: {s}", .{info_json});
 
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         // Reset arena to clear any previous server info strings
         _ = self.server_info_arena.reset(.retain_capacity);
@@ -1226,12 +1235,12 @@ pub const Connection = struct {
                 log.err("Failed to send CONNECT+PING: {}", .{err});
                 self.handshake_error = err;
                 self.handshake_state = .failed;
-                self.handshake_cond.broadcast();
+                self.handshake_cond.broadcast(self.io);
                 return;
             };
 
             self.handshake_state = .waiting_for_pong;
-            self.handshake_cond.broadcast(); // Signal state change
+            self.handshake_cond.broadcast(self.io); // Signal state change
             log.debug("Handshake: sent CONNECT+PING, waiting for PONG", .{});
         }
 
@@ -1251,8 +1260,8 @@ pub const Connection = struct {
     }
 
     pub fn processOK(self: *Self) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         log.debug("Received +OK", .{});
 
@@ -1319,8 +1328,8 @@ pub const Connection = struct {
         var callback: @TypeOf(self.options.callbacks.error_cb) = null;
         defer if (callback) |cb| cb(self, err_msg);
 
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         // Parse the protocol error once
         const protocol_err = parseProtocolError(err_msg, self.allocator);
@@ -1332,7 +1341,7 @@ pub const Connection = struct {
             // Propagate specific protocol errors to client
             self.handshake_error = protocol_err;
             self.handshake_state = .failed;
-            self.handshake_cond.broadcast(); // Signal handshake failure
+            self.handshake_cond.broadcast(self.io); // Signal handshake failure
             log.debug("Handshake failed: {}", .{protocol_err});
             return;
         }
@@ -1346,8 +1355,8 @@ pub const Connection = struct {
     fn sendPing(self: *Self, comptime lock: bool) !u64 {
         try self.write_buffer.append("PING\r\n");
 
-        if (lock) try self.mutex.lock();
-        defer if (lock) self.mutex.unlock();
+        if (lock) try self.mutex.lock(self.io);
+        defer if (lock) self.mutex.unlock(self.io);
 
         self.outgoing_pings += 1;
         return self.outgoing_pings;
@@ -1357,7 +1366,7 @@ pub const Connection = struct {
         if (self.options.ping_interval_ms == 0) return;
 
         const interval_ns = self.options.ping_interval_ms * std.time.ns_per_ms;
-        const elapsed_ns = self.ping_timer.read();
+        const elapsed_ns = self.ping_timer.read().toNanoseconds();
         if (elapsed_ns >= interval_ns) {
             _ = try self.sendPing(true);
             const current_pings = self.pings_out.fetchAdd(1, .monotonic) + 1;
@@ -1370,20 +1379,20 @@ pub const Connection = struct {
     }
 
     pub fn processPong(self: *Self) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         // Handle handshake completion
         if (self.handshake_state == .waiting_for_pong) {
             self.handshake_state = .completed;
-            self.handshake_cond.broadcast(); // Signal handshake completion
+            self.handshake_cond.broadcast(self.io); // Signal handshake completion
             log.debug("Handshake completed successfully", .{});
             return;
         }
 
         // Regular PONG handling for flush() calls
         self.incoming_pongs += 1;
-        self.pong_condition.broadcast();
+        self.pong_condition.broadcast(self.io);
 
         log.debug("Received PONG for ping_id={}", .{self.incoming_pongs});
 
@@ -1396,8 +1405,8 @@ pub const Connection = struct {
     }
 
     pub fn processPing(self: *Self) !void {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         try self.write_buffer.append("PONG\r\n");
     }
@@ -1411,7 +1420,7 @@ pub const Connection = struct {
         const jitter = self.options.reconnect.reconnect_jitter_ms;
 
         if (jitter > 0) {
-            var rng = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+            var rng = std.Random.DefaultPrng.init(@intCast(zio.Timestamp.now(.monotonic).toNanoseconds()));
             const random_jitter = rng.random().uintLessThan(u64, jitter);
             base_wait += random_jitter;
         }
@@ -1423,18 +1432,18 @@ pub const Connection = struct {
         log.debug("Re-establishing subscriptions", .{});
 
         // Track SIDs that shouldn't be re-subscribed and must be removed
-        var to_remove = ArrayList(u64){};
+        var to_remove = ArrayList(u64).empty;
         defer to_remove.deinit(self.allocator);
 
         {
-            self.subs_mutex.lockUncancelable();
-            defer self.subs_mutex.unlock();
+            self.subs_mutex.lockUncancelable(self.io);
+            defer self.subs_mutex.unlock(self.io);
 
             const allocator = self.scratch.allocator();
             defer self.resetScratch();
 
-            var buffer = ArrayList(u8){};
-            defer buffer.deinit(allocator);
+            var buffer: std.Io.Writer.Allocating = .init(allocator);
+            defer buffer.deinit();
 
             var iter = self.subscriptions.iterator();
             while (iter.next()) |entry| {
@@ -1458,14 +1467,14 @@ pub const Connection = struct {
 
                 // Send SUB command
                 if (sub.queue) |queue| {
-                    try buffer.writer(allocator).print("SUB {s} {s} {d}\r\n", .{ sub.subject, queue, sub.sid });
+                    try buffer.writer.print("SUB {s} {s} {d}\r\n", .{ sub.subject, queue, sub.sid });
                 } else {
-                    try buffer.writer(allocator).print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
+                    try buffer.writer.print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
                 }
 
                 // Send UNSUB with remaining limit if needed
                 if (adjusted_max) |remaining| {
-                    try buffer.writer(allocator).print("UNSUB {d} {d}\r\n", .{ sub.sid, remaining });
+                    try buffer.writer.print("UNSUB {d} {d}\r\n", .{ sub.sid, remaining });
                     log.debug("Re-subscribed to {s} with sid {d} and autounsubscribe limit {d} (delivered: {d})", .{ sub.subject, sub.sid, remaining, delivered });
                 } else {
                     log.debug("Re-subscribed to {s} with sid {d}", .{ sub.subject, sub.sid });
@@ -1473,8 +1482,8 @@ pub const Connection = struct {
             }
 
             // Send all subscription commands via write buffer
-            if (buffer.items.len > 0) {
-                try self.write_buffer.append(buffer.items);
+            if (buffer.written().len > 0) {
+                try self.write_buffer.append(buffer.written());
             }
         }
 
@@ -1488,25 +1497,22 @@ pub const Connection = struct {
     /// Returns error if handshake fails or times out
     fn waitForHandshakeCompletion(self: *Self) !void {
         const timeout_ns = self.options.timeout_ms * std.time.ns_per_ms;
-        var timer = std.time.Timer.start() catch {
-            log.err("Failed to start timer for handshake", .{});
-            return ConnectionError.ConnectionFailed;
-        };
+        var timer = zio.Stopwatch.start();
 
         while (!self.handshake_state.isFinished()) {
             log.debug("Handshake state: {}", .{self.handshake_state});
 
-            const elapsed_ns = timer.read();
+            const elapsed_ns = timer.read().toNanoseconds();
             if (elapsed_ns >= timeout_ns) {
                 log.err("Handshake timeout", .{});
                 self.handshake_error = ConnectionError.Timeout;
                 self.handshake_state = .failed;
-                self.handshake_cond.broadcast(); // Signal the state change
+                self.handshake_cond.broadcast(self.io); // Signal the state change
                 break;
             }
 
             const remaining_ns = timeout_ns - elapsed_ns;
-            self.handshake_cond.timedWait(&self.mutex, .fromNanoseconds(remaining_ns)) catch {};
+            self.handshake_cond.waitTimeout(self.io, &self.mutex, nsTimeout(remaining_ns)) catch {};
         }
 
         // Return the handshake error if it failed, or void if successful
@@ -1531,14 +1537,14 @@ pub const Connection = struct {
         _ = self.drain_subscription_count.fetchAdd(1, .release);
 
         // Start draining subscriptions
-        self.subs_mutex.lockUncancelable();
+        self.subs_mutex.lockUncancelable(self.io);
         var iter = self.subscriptions.valueIterator();
         while (iter.next()) |sub_ptr| {
             const sub = sub_ptr.*;
             _ = self.drain_subscription_count.fetchAdd(1, .release);
             sub.drain(); // Drain the subscription
         }
-        self.subs_mutex.unlock();
+        self.subs_mutex.unlock(self.io);
 
         // Release the blocker
         self.notifySubscriptionDrainComplete();
@@ -1569,9 +1575,9 @@ pub const Connection = struct {
         }
 
         if (timeout_ms) |timeout| {
-            try self.drain_completion.timedWait(.fromMilliseconds(timeout));
+            try self.drain_completion.waitTimeout(self.io, msTimeout(timeout));
         } else {
-            try self.drain_completion.wait();
+            try self.drain_completion.wait(self.io);
         }
     }
 
@@ -1588,8 +1594,8 @@ pub const Connection = struct {
     }
 
     fn sendDrainPing(self: *Self) void {
-        self.mutex.lockUncancelable();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.drain_ping_id > 0) return; // Already sent the last ping
 
@@ -1603,7 +1609,7 @@ pub const Connection = struct {
         const prev_state = self.drain_state.cmpxchgStrong(.draining_pubs, .drain_complete, .acq_rel, .acquire);
         if (prev_state != null) return; // Already completed
 
-        self.drain_completion.set();
+        self.drain_completion.set(self.io);
 
         return error.ShouldClose;
     }

--- a/src/io_util.zig
+++ b/src/io_util.zig
@@ -1,0 +1,25 @@
+// Copyright 2025 Lukas Lalinsky
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const Io = std.Io;
+
+/// Convert a nanosecond duration into an `std.Io.Timeout`.
+pub fn nsTimeout(ns: u64) Io.Timeout {
+    return .{ .duration = .{ .raw = .fromNanoseconds(@intCast(ns)), .clock = .awake } };
+}
+
+/// Convert a millisecond duration into an `std.Io.Timeout`.
+pub fn msTimeout(ms: u64) Io.Timeout {
+    return .{ .duration = .{ .raw = .fromMilliseconds(@intCast(ms)), .clock = .awake } };
+}

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const zio = @import("zio");
+const xsync = @import("xsync");
 const message_mod = @import("message.zig");
 const Message = message_mod.Message;
 const MessageList = message_mod.MessageList;
@@ -32,11 +33,11 @@ const log = @import("log.zig").log;
 
 // Helper function to replace jsonStringifyAlloc
 fn jsonStringifyAlloc(allocator: std.mem.Allocator, value: anytype, options: std.json.Stringify.Options) ![]u8 {
-    var buffer = std.ArrayList(u8){};
-    defer buffer.deinit(allocator);
+    var buffer: std.Io.Writer.Allocating = .init(allocator);
+    defer buffer.deinit();
 
-    try std.fmt.format(buffer.writer(allocator), "{f}", .{std.json.fmt(value, options)});
-    return buffer.toOwnedSlice(allocator);
+    try buffer.writer.print("{f}", .{std.json.fmt(value, options)});
+    return buffer.toOwnedSlice();
 }
 
 // Re-export JetStream message types
@@ -419,7 +420,7 @@ pub const PullSubscription = struct {
     /// Fetch ID counter for unique reply subjects
     fetch_id_counter: u64 = 0,
     /// Mutex for fiber safety
-    mutex: zio.Mutex = .{},
+    mutex: xsync.Mutex = .init,
 
     pub fn deinit(self: *PullSubscription) void {
         self.consumer_info.deinit();
@@ -432,8 +433,8 @@ pub const PullSubscription = struct {
     pub fn fetch(self: *PullSubscription, batch: usize, timeout_ms: u64) !MessageBatch {
         if (batch == 0) return error.InvalidBatchSize;
 
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.js.nc.io);
+        defer self.mutex.unlock(self.js.nc.io);
 
         // Generate unique fetch ID and reply subject
         self.fetch_id_counter += 1;
@@ -461,7 +462,7 @@ pub const PullSubscription = struct {
         try self.js.nc.publishRequest(api_subject, reply_subject, request_json);
 
         // Collect messages
-        var messages = std.ArrayList(*JetStreamMessage){};
+        var messages = std.ArrayList(*JetStreamMessage).empty;
         defer messages.deinit(self.js.nc.allocator);
 
         var batch_complete = false;

--- a/src/jetstream_kv.zig
+++ b/src/jetstream_kv.zig
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 const std = @import("std");
+const zio = @import("zio");
 const JetStream = @import("jetstream.zig").JetStream;
 const validation = @import("validation.zig");
 const StreamConfig = @import("jetstream.zig").StreamConfig;
@@ -246,7 +247,7 @@ pub const KVWatcher = struct {
             return null;
         }
 
-        var timer = try std.time.Timer.start();
+        var timer = zio.Stopwatch.start();
         var remaining_ns = timeout_ms * std.time.ns_per_ms;
         while (true) {
             const remaining_ms = remaining_ns / std.time.ns_per_ms;
@@ -278,7 +279,7 @@ pub const KVWatcher = struct {
                 return entry;
             }
 
-            const elapsed_ns = timer.lap();
+            const elapsed_ns = timer.lap().toNanoseconds();
             if (elapsed_ns > remaining_ns) {
                 return error.Timeout;
             }
@@ -651,10 +652,10 @@ pub const KV = struct {
         }
 
         const total_timeout_ms = self.js.nc.options.timeout_ms;
-        var timer = try std.time.Timer.start();
+        var timer = zio.Stopwatch.start();
 
         while (true) {
-            const elapsed_ms = timer.read() / std.time.ns_per_ms;
+            const elapsed_ms = timer.read().toNanoseconds() / std.time.ns_per_ms;
             if (elapsed_ms >= total_timeout_ms) {
                 return error.Timeout;
             }

--- a/src/jetstream_objstore.zig
+++ b/src/jetstream_objstore.zig
@@ -32,12 +32,25 @@ const log = @import("log.zig").log;
 
 // Helper function to replace std.json.stringifyAlloc
 fn jsonStringifyAlloc(allocator: std.mem.Allocator, value: anytype, options: std.json.Stringify.Options) ![]u8 {
-    var buffer = std.ArrayList(u8){};
-    defer buffer.deinit(allocator);
+    var buffer: std.Io.Writer.Allocating = .init(allocator);
+    defer buffer.deinit();
 
-    try std.fmt.format(buffer.writer(allocator), "{f}", .{std.json.fmt(value, options)});
-    return buffer.toOwnedSlice(allocator);
+    try buffer.writer.print("{f}", .{std.json.fmt(value, options)});
+    return buffer.toOwnedSlice();
 }
+
+/// Simple reader over a byte slice, usable with `ObjectStore.put`.
+pub const SliceReader = struct {
+    data: []const u8,
+    pos: usize = 0,
+
+    pub fn read(self: *SliceReader, buffer: []u8) error{}!usize {
+        const n = @min(buffer.len, self.data.len - self.pos);
+        @memcpy(buffer[0..n], self.data[self.pos..][0..n]);
+        self.pos += n;
+        return n;
+    }
+};
 
 // Default chunk size (128KB)
 const DEFAULT_CHUNK_SIZE: u32 = 128 * 1024;
@@ -386,8 +399,8 @@ pub const ObjectStore = struct {
 
     /// Put bytes as an object into the store (convenience method)
     pub fn putBytes(self: *ObjectStore, object_name: []const u8, data: []const u8) !Result(ObjectInfo) {
-        // Create a fixed buffer stream from the data
-        var stream = std.io.fixedBufferStream(data);
+        // Create a slice reader from the data
+        var stream = SliceReader{ .data = data };
 
         // Create ObjectMeta with store's default chunk size
         const meta = ObjectMeta{
@@ -399,7 +412,7 @@ pub const ObjectStore = struct {
         };
 
         // Use the primary put() method with the stream reader
-        return self.put(meta, stream.reader());
+        return self.put(meta, &stream);
     }
 
     /// Primary get method that returns a streaming result

--- a/src/message.zig
+++ b/src/message.zig
@@ -14,6 +14,8 @@
 
 const std = @import("std");
 const zio = @import("zio");
+const xsync = @import("xsync");
+const Io = std.Io;
 const Allocator = std.mem.Allocator;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
 
@@ -205,7 +207,7 @@ pub const Message = struct {
 
             const result = try self.headers.getOrPut(arena_allocator, owned_key);
             if (!result.found_existing) {
-                result.value_ptr.* = .{};
+                result.value_ptr.* = .empty;
             }
 
             try result.value_ptr.append(arena_allocator, owned_value);
@@ -223,7 +225,7 @@ pub const Message = struct {
         const owned_key = try arena_allocator.dupe(u8, key);
         const owned_value = try arena_allocator.dupe(u8, value);
 
-        var values: ArrayListUnmanaged([]const u8) = .{};
+        var values: ArrayListUnmanaged([]const u8) = .empty;
         try values.append(arena_allocator, owned_value);
 
         try self.headers.put(arena_allocator, owned_key, values);
@@ -316,22 +318,24 @@ pub const Message = struct {
 
 pub const MessagePool = struct {
     allocator: std.mem.Allocator,
+    io: Io,
     messages: MessageList = .{},
-    mutex: zio.Mutex = .{},
+    mutex: xsync.Mutex = .init,
     max_size: usize = 100,
     max_arena_size: usize = 1024 * 1024,
 
     pub const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator) MessagePool {
+    pub fn init(allocator: std.mem.Allocator, io: Io) MessagePool {
         return .{
             .allocator = allocator,
+            .io = io,
         };
     }
 
     pub fn deinit(self: *Self) void {
-        self.mutex.lockUncancelable();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
         while (self.messages.pop()) |msg| {
             msg.pool = null;
@@ -341,8 +345,8 @@ pub const MessagePool = struct {
     }
 
     pub fn acquire(self: *Self) !*Message {
-        try self.mutex.lock();
-        defer self.mutex.unlock();
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.messages.pop()) |msg| {
             return msg;
@@ -357,8 +361,8 @@ pub const MessagePool = struct {
     }
 
     pub fn release(self: *Self, msg: *Message) void {
-        self.mutex.lockUncancelable();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.messages.len < self.max_size) {
             msg.reset();

--- a/src/message_test.zig
+++ b/src/message_test.zig
@@ -147,20 +147,20 @@ test "Message header encoding" {
     try msg.headerSet("Content-Type", "application/json");
     try msg.headerSet("X-Custom", "value");
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
 
-    try msg.encodeHeaders(buf.writer(allocator));
+    try msg.encodeHeaders(&buf.writer);
 
     // Should start with NATS/1.0
-    try testing.expect(std.mem.startsWith(u8, buf.items, "NATS/1.0\r\n"));
+    try testing.expect(std.mem.startsWith(u8, buf.written(), "NATS/1.0\r\n"));
 
     // Should contain headers
-    try testing.expect(std.mem.indexOf(u8, buf.items, "Content-Type: application/json\r\n") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "X-Custom: value\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.written(), "Content-Type: application/json\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.written(), "X-Custom: value\r\n") != null);
 
     // Should end with double CRLF
-    try testing.expect(std.mem.endsWith(u8, buf.items, "\r\n\r\n"));
+    try testing.expect(std.mem.endsWith(u8, buf.written(), "\r\n\r\n"));
 }
 
 test "Message status field and header parsing" {
@@ -196,20 +196,20 @@ test "Message status field and header parsing" {
     try testing.expectEqualStrings("test", custom_header.?);
 
     // Test encoding - Status header should be first line
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var buf: std.Io.Writer.Allocating = .init(allocator);
+    defer buf.deinit();
 
-    try msg.encodeHeaders(buf.writer(allocator));
+    try msg.encodeHeaders(&buf.writer);
 
     // Should start with the full status line
-    try testing.expect(std.mem.startsWith(u8, buf.items, "NATS/1.0 503 No Responders\r\n"));
+    try testing.expect(std.mem.startsWith(u8, buf.written(), "NATS/1.0 503 No Responders\r\n"));
 
     // Should contain other headers
-    try testing.expect(std.mem.indexOf(u8, buf.items, "X-Custom: test\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.written(), "X-Custom: test\r\n") != null);
 
     // Should NOT contain Status or Description as regular headers
-    try testing.expect(std.mem.indexOf(u8, buf.items, "Status: 503\r\n") == null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "Description: No Responders\r\n") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.written(), "Status: 503\r\n") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.written(), "Description: No Responders\r\n") == null);
 }
 
 test "Message memory patterns" {

--- a/src/nuid.zig
+++ b/src/nuid.zig
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 const std = @import("std");
-const Mutex = std.Thread.Mutex;
+
+fn randomBytes(buffer: []u8) void {
+    std.Io.Threaded.global_single_threaded.io().random(buffer);
+}
 
 /// NUID (NATS Unique Identifier) implementation
 /// Uses 12 bytes of crypto-generated prefix + 10 bytes of sequential data
@@ -40,7 +43,7 @@ const Nuid = struct {
     fn randomizePrefix(self: *Nuid) void {
         // Generate a random number up to MAX_PREFIX and encode it in base36
         var random_bytes: [8]u8 = undefined;
-        std.crypto.random.bytes(&random_bytes);
+        randomBytes(&random_bytes);
 
         const random_val = std.mem.readInt(u64, &random_bytes, .little) % MAX_PREFIX;
         encodeBase36(random_val, self.prefix[0..]);
@@ -49,7 +52,7 @@ const Nuid = struct {
     fn resetSequence(self: *Nuid) void {
         // Generate random sequence start and increment
         var random_bytes: [16]u8 = undefined;
-        std.crypto.random.bytes(&random_bytes);
+        randomBytes(&random_bytes);
 
         const inc_random = std.mem.readInt(u64, random_bytes[0..8], .little);
         self.increment = MIN_INCREMENT + (inc_random % (MAX_INCREMENT - MIN_INCREMENT + 1));
@@ -79,19 +82,19 @@ const Nuid = struct {
 
 /// Thread-safe global NUID instance
 const GlobalNuid = struct {
-    mutex: Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     nuid: Nuid = .{},
 
     fn reset(self: *GlobalNuid) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        std.Io.Threaded.mutexLock(&self.mutex);
+        defer std.Io.Threaded.mutexUnlock(&self.mutex);
 
         self.nuid = .{};
     }
 
     fn next(self: *GlobalNuid, buffer: *[NUID_TOTAL_LEN]u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        std.Io.Threaded.mutexLock(&self.mutex);
+        defer std.Io.Threaded.mutexUnlock(&self.mutex);
 
         self.nuid.next(buffer);
     }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -58,7 +58,7 @@ pub const ParserState = enum {
 pub const MsgArg = struct {
     msg: ?*Message = null,
     payload_buffer: []u8 = undefined,
-    payload_writer: std.io.FixedBufferStream([]u8) = undefined,
+    payload_pos: usize = 0,
 };
 
 // Forward declaration for connection
@@ -77,11 +77,11 @@ pub const Parser = struct {
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator) Self {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) Self {
         return Self{
             .allocator = allocator,
-            .arg_buf_rec = std.ArrayList(u8){},
-            .msg_pool = MessagePool.init(allocator),
+            .arg_buf_rec = std.ArrayList(u8).empty,
+            .msg_pool = MessagePool.init(allocator, io),
         };
     }
 
@@ -206,15 +206,15 @@ pub const Parser = struct {
                 .MSG_PAYLOAD => {
                     const msg = self.ma.msg orelse unreachable;
 
-                    var needed = self.ma.payload_buffer.len - self.ma.payload_writer.pos;
+                    var needed = self.ma.payload_buffer.len - self.ma.payload_pos;
                     const available = buf.len - i;
                     const to_copy = @min(needed, available);
 
                     if (to_copy > 0) {
-                        const written = try self.ma.payload_writer.write(buf[i .. i + to_copy]);
-                        std.debug.assert(written == to_copy);
+                        @memcpy(self.ma.payload_buffer[self.ma.payload_pos..][0..to_copy], buf[i .. i + to_copy]);
+                        self.ma.payload_pos += to_copy;
                         i += to_copy - 1;
-                        needed -= written;
+                        needed -= to_copy;
                     }
 
                     if (needed == 0) {
@@ -570,7 +570,7 @@ pub const Parser = struct {
         self.ma = MsgArg{
             .msg = msg,
             .payload_buffer = payload_buffer,
-            .payload_writer = std.io.fixedBufferStream(payload_buffer),
+            .payload_pos = 0,
         };
     }
 };
@@ -627,7 +627,7 @@ const MockConnection = struct {
 test "parser ping pong" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{};
@@ -645,7 +645,7 @@ test "parser ping pong" {
 test "parser ok" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{};
@@ -658,7 +658,7 @@ test "parser ok" {
 test "parser err" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{};
@@ -672,7 +672,7 @@ test "parser err" {
 test "parser info" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{};
@@ -688,7 +688,7 @@ test "parser info" {
 test "parser msg" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{};
@@ -704,7 +704,7 @@ test "parser msg" {
 test "parser msg with reply" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{ .parser_ref = &parser };
@@ -718,7 +718,7 @@ test "parser msg with reply" {
 test "parser hmsg" {
     const testing = std.testing;
 
-    var parser = Parser.init(testing.allocator);
+    var parser = Parser.init(testing.allocator, std.testing.io);
     defer parser.deinit();
 
     var mock_conn = MockConnection{ .parser_ref = &parser };
@@ -730,15 +730,11 @@ test "parser hmsg" {
 }
 
 fn parseInChunks(parser: *Parser, conn: *MockConnection, data: []const u8, chunk_size: usize) !void {
-    var stream = std.io.fixedBufferStream(data);
-    const reader = stream.reader();
-
-    while (true) {
-        var buf: [1024]u8 = undefined;
-        std.debug.assert(chunk_size <= buf.len);
-        const n = try reader.read(buf[0..chunk_size]);
-        if (n == 0) break;
-        try parser.parse(conn, buf[0..n]);
+    var offset: usize = 0;
+    while (offset < data.len) {
+        const end = @min(offset + chunk_size, data.len);
+        try parser.parse(conn, data[offset..end]);
+        offset = end;
     }
 }
 
@@ -747,7 +743,7 @@ test "parser split msg" {
     for (1..data.len) |chunk_size| {
         log.debug("chunk_size: {}", .{chunk_size});
 
-        var parser = Parser.init(std.testing.allocator);
+        var parser = Parser.init(std.testing.allocator, std.testing.io);
         defer parser.deinit();
 
         var capture = MockConnection{};
@@ -766,7 +762,7 @@ test "parser split hmsg" {
     for (1..data.len) |chunk_size| {
         log.info("chunk_size: {}", .{chunk_size});
 
-        var parser = Parser.init(std.testing.allocator);
+        var parser = Parser.init(std.testing.allocator, std.testing.io);
         defer parser.deinit();
 
         var capture = MockConnection{};
@@ -790,7 +786,7 @@ test "parser split err" {
     for (1..data.len) |chunk_size| {
         log.info("chunk_size: {}", .{chunk_size});
 
-        var parser = Parser.init(std.testing.allocator);
+        var parser = Parser.init(std.testing.allocator, std.testing.io);
         defer parser.deinit();
 
         var capture = MockConnection{};
@@ -808,7 +804,7 @@ test "parser split info" {
     for (1..data.len) |chunk_size| {
         log.info("chunk_size: {}", .{chunk_size});
 
-        var parser = Parser.init(std.testing.allocator);
+        var parser = Parser.init(std.testing.allocator, std.testing.io);
         defer parser.deinit();
 
         var capture = MockConnection{};
@@ -833,7 +829,7 @@ test "parser multiple lines" {
     for (1..data.len) |chunk_size| {
         log.info("chunk_size: {}", .{chunk_size});
 
-        var parser = Parser.init(std.testing.allocator);
+        var parser = Parser.init(std.testing.allocator, std.testing.io);
         defer parser.deinit();
 
         var capture = MockConnection{};

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -13,7 +13,11 @@
 
 const std = @import("std");
 const zio = @import("zio");
+const xsync = @import("xsync");
+const Io = std.Io;
 const Allocator = std.mem.Allocator;
+
+const nsTimeout = @import("io_util.zig").nsTimeout;
 
 const PopError = error{
     QueueEmpty,
@@ -133,7 +137,7 @@ fn ChunkPool(comptime T: type, comptime chunk_size: usize) type {
         fn init(allocator: Allocator, max_size: usize) Self {
             _ = allocator;
             return .{
-                .chunks = std.ArrayList(*Chunk){},
+                .chunks = std.ArrayList(*Chunk).empty,
                 .max_size = max_size,
             };
         }
@@ -166,10 +170,13 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
     return struct {
         allocator: Allocator,
 
+        /// The `std.Io` instance used for blocking and waking
+        io: Io,
+
         /// Single mutex protecting all operations
-        mutex: zio.Mutex,
+        mutex: xsync.Mutex,
         /// Condition variable for waiting readers
-        data_cond: zio.Condition,
+        data_cond: xsync.Condition,
 
         /// Head of the linked list (oldest chunk, protected by mutex)
         head: ?*Chunk,
@@ -209,11 +216,12 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             max_size: usize = 0,
         };
 
-        pub fn init(allocator: Allocator, config: Config) Self {
+        pub fn init(allocator: Allocator, io: Io, config: Config) Self {
             return .{
                 .allocator = allocator,
-                .mutex = .{},
-                .data_cond = .{},
+                .io = io,
+                .mutex = .init,
+                .data_cond = .init,
                 .head = null,
                 .tail = null,
                 .items_available = 0,
@@ -241,9 +249,9 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         }
 
         /// Push a single item (fiber-safe, cancelable)
-        pub fn push(self: *Self, item: T) (zio.Cancelable || PushError)!void {
-            try self.mutex.lock();
-            defer self.mutex.unlock();
+        pub fn push(self: *Self, item: T) (Io.Cancelable || PushError)!void {
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
 
             if (self.is_closed) {
                 return PushError.QueueClosed;
@@ -269,13 +277,13 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             }
 
             self.items_available += 1;
-            self.data_cond.signal();
+            self.data_cond.signal(self.io);
         }
 
         /// Push multiple items (fiber-safe, cancelable)
-        pub fn pushSlice(self: *Self, items: []const T) (zio.Cancelable || PushError)!void {
-            try self.mutex.lock();
-            defer self.mutex.unlock();
+        pub fn pushSlice(self: *Self, items: []const T) (Io.Cancelable || PushError)!void {
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
 
             if (self.is_closed) {
                 return PushError.QueueClosed;
@@ -315,12 +323,12 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             }
 
             self.items_available += total_written;
-            self.data_cond.signal();
+            self.data_cond.signal(self.io);
         }
 
         /// Internal helper to wait for data availability with timeout handling
         /// Assumes mutex is already held.
-        fn waitForDataInternal(self: *Self, timeout_ms: u64) (zio.Cancelable || PopError)!void {
+        fn waitForDataInternal(self: *Self, timeout_ms: u64) (Io.Cancelable || PopError)!void {
             // Fast path for non-blocking (timeout_ms == 0)
             if (timeout_ms == 0) {
                 if (self.is_closed and self.items_available == 0) {
@@ -336,7 +344,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             } else if (timeout_ms == std.math.maxInt(u64)) {
                 // Wait indefinitely
                 while ((self.items_available == 0 or self.is_frozen) and !self.is_closed) {
-                    try self.data_cond.wait(&self.mutex);
+                    try self.data_cond.wait(self.io, &self.mutex);
                 }
 
                 if (self.is_closed and self.items_available == 0) {
@@ -345,11 +353,11 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return;
             } else {
                 // Wait with timeout
-                var timer = std.time.Timer.start() catch unreachable;
+                var timer = zio.Stopwatch.start();
                 const timeout_ns = timeout_ms * std.time.ns_per_ms;
 
                 while ((self.items_available == 0 or self.is_frozen) and !self.is_closed) {
-                    const elapsed_ns = timer.read();
+                    const elapsed_ns = timer.read().toNanoseconds();
                     if (elapsed_ns >= timeout_ns) {
                         if (self.is_closed and self.items_available == 0) {
                             return PopError.QueueClosed;
@@ -361,7 +369,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                     }
 
                     const remaining_ns = timeout_ns - elapsed_ns;
-                    self.data_cond.timedWait(&self.mutex, .fromNanoseconds(remaining_ns)) catch |err| switch (err) {
+                    self.data_cond.waitTimeout(self.io, &self.mutex, nsTimeout(remaining_ns)) catch |err| switch (err) {
                         error.Canceled => return error.Canceled,
                         error.Timeout => {}, // Continue loop to check conditions
                     };
@@ -375,9 +383,9 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         }
 
         /// Pop a single item with timeout (0 = non-blocking)
-        pub fn pop(self: *Self, timeout_ms: u64) (zio.Cancelable || PopError)!T {
-            try self.mutex.lock();
-            defer self.mutex.unlock();
+        pub fn pop(self: *Self, timeout_ms: u64) (Io.Cancelable || PopError)!T {
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
 
             try self.waitForDataInternal(timeout_ms);
 
@@ -407,9 +415,9 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         }
 
         /// Get readable slice with timeout (0 = non-blocking, maxInt(u64) = wait forever)
-        pub fn getSlice(self: *Self, timeout_ms: u64) (zio.Cancelable || PopError)!View {
-            try self.mutex.lock();
-            defer self.mutex.unlock();
+        pub fn getSlice(self: *Self, timeout_ms: u64) (Io.Cancelable || PopError)!View {
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
 
             try self.waitForDataInternal(timeout_ms);
 
@@ -434,8 +442,8 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
         /// Consume items after processing
         pub fn consumeItems(self: *Self, chunk: *Chunk, items_consumed: usize) void {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             chunk.read_pos += items_consumed;
             self.items_available -= items_consumed;
@@ -456,67 +464,67 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
         /// Get total items available for reading
         pub fn getItemsAvailable(self: *Self) usize {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             return self.items_available;
         }
 
         /// Check if queue has data
         pub fn hasData(self: *Self) bool {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             return self.items_available > 0;
         }
 
         /// Close the queue to prevent further writes
         pub fn close(self: *Self) void {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             self.is_closed = true;
             self.is_frozen = false;
-            self.data_cond.broadcast();
+            self.data_cond.broadcast(self.io);
         }
 
         /// Check if the queue is closed
         pub fn isClosed(self: *Self) bool {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             return self.is_closed;
         }
 
         /// Freeze the buffer (blocks both readers and writers)
         pub fn freeze(self: *Self) void {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             self.is_frozen = true;
         }
 
         /// Unfreeze the buffer and wake up waiting fibers
         pub fn unfreeze(self: *Self) void {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             self.is_frozen = false;
-            self.data_cond.broadcast();
+            self.data_cond.broadcast(self.io);
         }
 
         /// Check if buffer is frozen
         pub fn isFrozen(self: *Self) bool {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             return self.is_frozen;
         }
 
         /// Reset the queue to empty state
         pub fn reset(self: *Self) void {
-            self.mutex.lockUncancelable();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
 
             // Free all chunks in the linked list
             var current = self.head;
@@ -535,7 +543,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             self.reset_id +%= 1;
 
             // Wake up any waiting fibers
-            self.data_cond.broadcast();
+            self.data_cond.broadcast(self.io);
         }
 
         // Private helper functions
@@ -596,13 +604,13 @@ pub fn VectorGather(comptime T: type, comptime chunk_size: usize) type {
 
         const Self = @This();
 
-        pub fn consume(self: Self, bytes_consumed: usize) (zio.Cancelable || error{ BufferReset, ConcurrentConsumer })!void {
+        pub fn consume(self: Self, bytes_consumed: usize) (Io.Cancelable || error{ BufferReset, ConcurrentConsumer })!void {
             if (bytes_consumed > self.total_bytes) {
                 std.debug.panic("Attempting to consume {} bytes but only {} were gathered", .{ bytes_consumed, self.total_bytes });
             }
 
-            try self.buffer.queue.mutex.lock();
-            defer self.buffer.queue.mutex.unlock();
+            try self.buffer.queue.mutex.lock(self.buffer.queue.io);
+            defer self.buffer.queue.mutex.unlock(self.buffer.queue.io);
 
             // Validate reset ID hasn't changed
             if (self.reset_id != self.buffer.queue.reset_id) {
@@ -635,9 +643,9 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         pub const Config = Queue.Config;
         pub const Gather = VectorGather(u8, chunk_size);
 
-        pub fn init(allocator: Allocator, config: Config) Self {
+        pub fn init(allocator: Allocator, io: Io, config: Config) Self {
             return .{
-                .queue = Queue.init(allocator, config),
+                .queue = Queue.init(allocator, io, config),
             };
         }
 
@@ -646,15 +654,15 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         }
 
         /// Append bytes to the buffer
-        pub fn append(self: *Self, data: []const u8) (zio.Cancelable || PushError)!void {
+        pub fn append(self: *Self, data: []const u8) (Io.Cancelable || PushError)!void {
             return self.queue.pushSlice(data);
         }
 
         /// Append multiple slices to the buffer in a single operation
         /// More efficient than calling append() multiple times as it only takes the lock once
-        pub fn appendMany(self: *Self, slices: []const []const u8) (zio.Cancelable || PushError)!void {
-            try self.queue.mutex.lock();
-            defer self.queue.mutex.unlock();
+        pub fn appendMany(self: *Self, slices: []const []const u8) (Io.Cancelable || PushError)!void {
+            try self.queue.mutex.lock(self.queue.io);
+            defer self.queue.mutex.unlock(self.queue.io);
 
             if (self.queue.is_closed) {
                 return PushError.QueueClosed;
@@ -702,7 +710,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
             }
 
             self.queue.items_available += total_size;
-            self.queue.data_cond.signal();
+            self.queue.data_cond.signal(self.queue.io);
         }
 
         /// Close the buffer to prevent further writes
@@ -721,7 +729,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         }
 
         /// Get readable byte slice with timeout
-        pub fn getSlice(self: *Self, timeout_ms: u64) (zio.Cancelable || PopError)!Queue.View {
+        pub fn getSlice(self: *Self, timeout_ms: u64) (Io.Cancelable || PopError)!Queue.View {
             return self.queue.getSlice(timeout_ms);
         }
 
@@ -756,9 +764,9 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         }
 
         /// Get multiple readable slices for vectored I/O with timeout (0 = non-blocking)
-        pub fn gatherReadSlices(self: *Self, slices: [][]const u8, timeout_ms: u64) (zio.Cancelable || PopError)!Gather {
-            try self.queue.mutex.lock();
-            defer self.queue.mutex.unlock();
+        pub fn gatherReadSlices(self: *Self, slices: [][]const u8, timeout_ms: u64) (Io.Cancelable || PopError)!Gather {
+            try self.queue.mutex.lock(self.queue.io);
+            defer self.queue.mutex.unlock(self.queue.io);
 
             try self.queue.waitForDataInternal(timeout_ms);
 
@@ -833,7 +841,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         }
 
         /// Move all data from this buffer to another buffer atomically (no copy).
-        pub fn moveToBuffer(self: *Self, dest: *Self) (zio.Cancelable || PushError)!void {
+        pub fn moveToBuffer(self: *Self, dest: *Self) (Io.Cancelable || PushError)!void {
             if (self == dest) return; // no-op
 
             // Lock both buffers in a stable order to avoid deadlocks.
@@ -842,10 +850,10 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
             var first: *Self = if (self_addr <= dest_addr) self else dest;
             var second: *Self = if (self_addr <= dest_addr) dest else self;
 
-            try first.queue.mutex.lock();
-            defer first.queue.mutex.unlock();
-            try second.queue.mutex.lock();
-            defer second.queue.mutex.unlock();
+            try first.queue.mutex.lock(first.queue.io);
+            defer first.queue.mutex.unlock(first.queue.io);
+            try second.queue.mutex.lock(second.queue.io);
+            defer second.queue.mutex.unlock(second.queue.io);
 
             // Respect freeze semantics:
             if (dest.queue.is_frozen) {
@@ -895,7 +903,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
             dest.queue.items_available += self.queue.items_available;
             dest.queue.total_chunks += moved_chunk_count;
             // Wake a waiting reader on dest (consistent with push/pushSlice)
-            dest.queue.data_cond.signal();
+            dest.queue.data_cond.signal(dest.queue.io);
 
             // Reset source queue state (we transferred ownership).
             self.queue.head = null;
@@ -907,31 +915,31 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         }
 
         /// Wait for data to become available with timeout (0 = non-blocking)
-        pub fn waitForData(self: *Self, timeout_ms: u64) (zio.Cancelable || PopError)!void {
-            try self.queue.mutex.lock();
-            defer self.queue.mutex.unlock();
+        pub fn waitForData(self: *Self, timeout_ms: u64) (Io.Cancelable || PopError)!void {
+            try self.queue.mutex.lock(self.queue.io);
+            defer self.queue.mutex.unlock(self.queue.io);
 
             try self.queue.waitForDataInternal(timeout_ms);
         }
 
         /// Wait for more data to become available with timeout
-        pub fn waitForMoreData(self: *Self, timeout_ns: u64) (zio.Cancelable || error{QueueClosed})!void {
-            try self.queue.mutex.lock();
-            defer self.queue.mutex.unlock();
+        pub fn waitForMoreData(self: *Self, timeout_ns: u64) (Io.Cancelable || error{QueueClosed})!void {
+            try self.queue.mutex.lock(self.queue.io);
+            defer self.queue.mutex.unlock(self.queue.io);
 
             if (self.queue.is_closed) {
                 return error.QueueClosed;
             }
 
             const initial_data = self.queue.items_available;
-            var timer = std.time.Timer.start() catch unreachable;
+            var timer = zio.Stopwatch.start();
 
             while (self.queue.items_available <= initial_data and !self.queue.is_closed) {
-                const elapsed_ns = timer.read();
+                const elapsed_ns = timer.read().toNanoseconds();
                 if (elapsed_ns >= timeout_ns) break;
 
                 const remaining_ns = timeout_ns - elapsed_ns;
-                self.queue.data_cond.timedWait(&self.queue.mutex, .fromNanoseconds(remaining_ns)) catch |err| switch (err) {
+                self.queue.data_cond.waitTimeout(self.queue.io, &self.queue.mutex, nsTimeout(remaining_ns)) catch |err| switch (err) {
                     error.Canceled => return error.Canceled,
                     error.Timeout => {}, // Continue loop
                 };
@@ -953,7 +961,7 @@ test "generic queue with integers" {
     defer rt.deinit();
 
     const IntQueue = ConcurrentQueue(i32, 4);
-    var queue = IntQueue.init(allocator, .{});
+    var queue = IntQueue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Push individual items
@@ -980,7 +988,7 @@ test "generic queue with structs" {
     };
 
     const MsgQueue = ConcurrentQueue(Message, 16);
-    var queue = MsgQueue.init(allocator, .{});
+    var queue = MsgQueue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Push messages
@@ -1007,7 +1015,7 @@ test "byte buffer specialization" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     try buffer.append("Hello, World!");
@@ -1026,7 +1034,7 @@ test "concurrent push and pop" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(u64, 32);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     var sum: u64 = 0;
@@ -1064,7 +1072,7 @@ test "queue close functionality" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Push some items before closing
@@ -1093,10 +1101,10 @@ test "blocking pop handles queue closure" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
-    var pop_result: ?(zio.Cancelable || PopError) = null;
+    var pop_result: ?(Io.Cancelable || PopError) = null;
 
     const TestFn = struct {
         fn closer(q: *Queue) void {
@@ -1104,7 +1112,7 @@ test "blocking pop handles queue closure" {
             q.close();
         }
 
-        fn popper(q: *Queue, result: *?(zio.Cancelable || PopError)) void {
+        fn popper(q: *Queue, result: *?(Io.Cancelable || PopError)) void {
             _ = q.pop(1000) catch |err| {
                 result.* = err;
                 return;
@@ -1130,10 +1138,10 @@ test "getSlice handles queue closure with indefinite wait" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
-    var get_result: ?(zio.Cancelable || PopError) = null;
+    var get_result: ?(Io.Cancelable || PopError) = null;
 
     const TestFn = struct {
         fn closer(q: *Queue) void {
@@ -1141,7 +1149,7 @@ test "getSlice handles queue closure with indefinite wait" {
             q.close();
         }
 
-        fn getter(q: *Queue, result: *?(zio.Cancelable || PopError)) void {
+        fn getter(q: *Queue, result: *?(Io.Cancelable || PopError)) void {
             _ = q.getSlice(std.math.maxInt(u64)) catch |err| {
                 result.* = err;
                 return;
@@ -1167,7 +1175,7 @@ test "buffer close functionality" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Append some data before closing
@@ -1197,10 +1205,10 @@ test "buffer moveToBuffer functionality" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(32);
-    var source = Buffer.init(allocator, .{});
+    var source = Buffer.init(allocator, rt.io(), .{});
     defer source.deinit();
 
-    var dest = Buffer.init(allocator, .{});
+    var dest = Buffer.init(allocator, rt.io(), .{});
     defer dest.deinit();
 
     // Add data to source buffer
@@ -1235,10 +1243,10 @@ test "buffer moveToBuffer with multiple chunks" {
 
     // Use small chunk size to force multiple chunks
     const Buffer = ConcurrentWriteBuffer(8);
-    var source = Buffer.init(allocator, .{});
+    var source = Buffer.init(allocator, rt.io(), .{});
     defer source.deinit();
 
-    var dest = Buffer.init(allocator, .{});
+    var dest = Buffer.init(allocator, rt.io(), .{});
     defer dest.deinit();
 
     // Add data that spans multiple chunks
@@ -1259,7 +1267,7 @@ test "buffer moveToBuffer with multiple chunks" {
     try std.testing.expectEqual(total_bytes, dest.getBytesAvailable());
 
     // Read and verify the moved data by consuming all chunks
-    var result = std.ArrayList(u8){};
+    var result = std.ArrayList(u8).empty;
     defer result.deinit(allocator);
 
     while (dest.getBytesAvailable() > 0) {
@@ -1282,10 +1290,10 @@ test "buffer moveToBuffer empty source" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var source = Buffer.init(allocator, .{});
+    var source = Buffer.init(allocator, rt.io(), .{});
     defer source.deinit();
 
-    var dest = Buffer.init(allocator, .{});
+    var dest = Buffer.init(allocator, rt.io(), .{});
     defer dest.deinit();
 
     // Add some data to destination first
@@ -1311,7 +1319,7 @@ test "buffer max_size limit" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{ .max_size = 10 });
+    var buffer = Buffer.init(allocator, rt.io(), .{ .max_size = 10 });
     defer buffer.deinit();
 
     // Should be able to add up to max_size
@@ -1340,7 +1348,7 @@ test "freeze/unfreeze basic functionality" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Add some data
@@ -1374,7 +1382,7 @@ test "writers cannot push while buffer is frozen" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Freeze buffer
@@ -1403,7 +1411,7 @@ test "blocking operations during freeze" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     queue.freeze();
@@ -1440,7 +1448,7 @@ test "timeout while frozen returns BufferFrozen" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Add data then freeze buffer
@@ -1462,7 +1470,7 @@ test "freeze/unfreeze interaction with close" {
     defer rt.deinit();
 
     const Queue = ConcurrentQueue(i32, 4);
-    var queue = Queue.init(allocator, .{});
+    var queue = Queue.init(allocator, rt.io(), .{});
     defer queue.deinit();
 
     // Freeze then close
@@ -1483,7 +1491,7 @@ test "ConcurrentWriteBuffer freeze/unfreeze functionality" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Add some data
@@ -1522,7 +1530,7 @@ test "ConcurrentWriteBuffer waitForData smoke test" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Test waitForData with immediate data available
@@ -1543,7 +1551,7 @@ test "ConcurrentWriteBuffer waitForData with closed buffer" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Close the buffer
@@ -1560,7 +1568,7 @@ test "ConcurrentWriteBuffer waitForMoreData smoke test" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Add initial data
@@ -1581,7 +1589,7 @@ test "ConcurrentWriteBuffer waitForMoreData with closed buffer" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Close the buffer
@@ -1598,7 +1606,7 @@ test "gatherReadSlices respects freeze state" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Add data to buffer
@@ -1636,7 +1644,7 @@ test "VectorGather thread safety validation" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     try buffer.append("Hello, World!");
@@ -1662,7 +1670,7 @@ test "VectorGather blocking behavior" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     // Should return QueueEmpty immediately when no data (non-blocking)
@@ -1696,10 +1704,10 @@ test "moveToBuffer respects freeze state on source" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var source = Buffer.init(allocator, .{});
+    var source = Buffer.init(allocator, rt.io(), .{});
     defer source.deinit();
 
-    var dest = Buffer.init(allocator, .{});
+    var dest = Buffer.init(allocator, rt.io(), .{});
     defer dest.deinit();
 
     // Add data to source
@@ -1723,10 +1731,10 @@ test "moveToBuffer respects freeze state on destination" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var source = Buffer.init(allocator, .{});
+    var source = Buffer.init(allocator, rt.io(), .{});
     defer source.deinit();
 
-    var dest = Buffer.init(allocator, .{});
+    var dest = Buffer.init(allocator, rt.io(), .{});
     defer dest.deinit();
 
     // Add data to source
@@ -1750,7 +1758,7 @@ test "VectorGather detects buffer reset between gather and consume" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     try buffer.append("Hello, World!");
@@ -1773,7 +1781,7 @@ test "VectorGather detects concurrent consumer advancing buffer" {
     defer rt.deinit();
 
     const Buffer = ConcurrentWriteBuffer(64);
-    var buffer = Buffer.init(allocator, .{});
+    var buffer = Buffer.init(allocator, rt.io(), .{});
     defer buffer.deinit();
 
     try buffer.append("Hello, World!");

--- a/src/request_reply_test.zig
+++ b/src/request_reply_test.zig
@@ -20,7 +20,7 @@ const Subscription = nats.Subscription;
 const inbox = nats.inbox;
 
 test "request reply basic functionality" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -58,7 +58,7 @@ test "inbox generation uniqueness" {
 }
 
 test "subscription timeout" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -75,7 +75,7 @@ test "subscription timeout" {
 }
 
 test "publish request format" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -88,7 +88,7 @@ test "publish request format" {
 }
 
 test "unsubscribe functionality" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -13,6 +13,9 @@
 
 const std = @import("std");
 const zio = @import("zio");
+const xsync = @import("xsync");
+const Io = std.Io;
+const nsTimeout = @import("io_util.zig").nsTimeout;
 const Allocator = std.mem.Allocator;
 const Message = @import("message.zig").Message;
 const MessageList = @import("message.zig").MessageList;
@@ -49,6 +52,7 @@ const INBOX_PREFIX_LEN = INBOX_BASE_PREFIX_LEN + nuid.NUID_TOTAL_LEN + 1; // "_I
 
 pub const ResponseManager = struct {
     allocator: Allocator,
+    io: Io,
 
     resp_sub_prefix_buf: [INBOX_PREFIX_LEN]u8 = undefined,
     resp_sub_prefix: []u8 = &.{},
@@ -60,8 +64,8 @@ pub const ResponseManager = struct {
     // "thundering herd" effects with many concurrent requests, we can optimize by
     // storing per-request condition variables in the pending_responses map and
     // signaling only the specific waiting fiber. This trades memory for CPU efficiency.
-    pending_mutex: zio.Mutex = .{},
-    pending_condition: zio.Condition = .{},
+    pending_mutex: xsync.Mutex = .init,
+    pending_condition: xsync.Condition = .init,
     is_closed: bool = false,
 
     // Map of rid -> result
@@ -70,16 +74,17 @@ pub const ResponseManager = struct {
     // Request ID generation state (simple counter)
     rid_counter: u64 = 0,
 
-    pub fn init(allocator: Allocator) ResponseManager {
+    pub fn init(allocator: Allocator, io: Io) ResponseManager {
         return ResponseManager{
             .allocator = allocator,
+            .io = io,
         };
     }
 
     pub fn deinit(self: *ResponseManager) void {
         // Signal shutdown and wake up all waiters
-        self.pending_mutex.lockUncancelable();
-        defer self.pending_mutex.unlock();
+        self.pending_mutex.lockUncancelable(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         // Clean up the response subscription if it exists
         if (self.resp_mux) |sub| {
@@ -88,7 +93,7 @@ pub const ResponseManager = struct {
         }
 
         self.is_closed = true;
-        self.pending_condition.broadcast(); // Wake up all waiters
+        self.pending_condition.broadcast(self.io); // Wake up all waiters
 
         // Clean up any remaining pending responses
         if (self.pending_responses.count() > 0) {
@@ -114,8 +119,8 @@ pub const ResponseManager = struct {
     }
 
     pub fn ensureInitialized(self: *ResponseManager, connection: *Connection) !void {
-        try self.pending_mutex.lock();
-        defer self.pending_mutex.unlock();
+        try self.pending_mutex.lock(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         // Already initialized by another thread
         if (self.resp_mux != null) return;
@@ -136,8 +141,8 @@ pub const ResponseManager = struct {
     }
 
     pub fn createRequest(self: *ResponseManager) !RequestHandle {
-        try self.pending_mutex.lock();
-        defer self.pending_mutex.unlock();
+        try self.pending_mutex.lock(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         if (self.is_closed) return error.ConnectionClosed;
 
@@ -150,8 +155,8 @@ pub const ResponseManager = struct {
     }
 
     pub fn createMultiRequest(self: *ResponseManager) !RequestHandle {
-        try self.pending_mutex.lock();
-        defer self.pending_mutex.unlock();
+        try self.pending_mutex.lock(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         if (self.is_closed) return error.ConnectionClosed;
 
@@ -183,12 +188,12 @@ pub const ResponseManager = struct {
         }
 
         self.pending_responses.removeByPtr(entry.key_ptr);
-        self.pending_condition.broadcast();
+        self.pending_condition.broadcast(self.io);
     }
 
     pub fn cleanupRequest(self: *ResponseManager, handle: RequestHandle) void {
-        self.pending_mutex.lockUncancelable();
-        defer self.pending_mutex.unlock();
+        self.pending_mutex.lockUncancelable(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         const entry = self.pending_responses.getEntry(handle.rid) orelse return;
         self.cleanupRequestInternal(entry);
@@ -197,12 +202,12 @@ pub const ResponseManager = struct {
     }
 
     pub fn waitForResponse(self: *ResponseManager, handle: RequestHandle, timeout_ns: u64) !*Message {
-        try self.pending_mutex.lock();
-        defer self.pending_mutex.unlock();
+        try self.pending_mutex.lock(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         if (self.is_closed) return error.ConnectionClosed;
 
-        var timer = std.time.Timer.start() catch unreachable;
+        var timer = zio.Stopwatch.start();
         while (true) {
             // Look up entry fresh each iteration - previous pointers may be invalid after timedWait
             const entry = self.pending_responses.getEntry(handle.rid) orelse {
@@ -229,7 +234,7 @@ pub const ResponseManager = struct {
                 return error.ConnectionClosed;
             }
 
-            const elapsed = timer.read();
+            const elapsed = timer.read().toNanoseconds();
             if (elapsed >= timeout_ns) {
                 cleanup = true;
                 return error.Timeout;
@@ -237,7 +242,7 @@ pub const ResponseManager = struct {
 
             // After this call, any entry pointers become invalid due to potential HashMap modifications
             cleanup = false;
-            self.pending_condition.timedWait(&self.pending_mutex, .fromNanoseconds(timeout_ns - elapsed)) catch {};
+            self.pending_condition.waitTimeout(self.io, &self.pending_mutex, nsTimeout(timeout_ns - elapsed)) catch {};
         }
     }
 
@@ -256,8 +261,8 @@ pub const ResponseManager = struct {
     };
 
     pub fn waitForMultiResponse(self: *ResponseManager, handle: RequestHandle, timeout_ns: u64, options: WaitForMultiResponseOptions) !MessageList {
-        try self.pending_mutex.lock();
-        defer self.pending_mutex.unlock();
+        try self.pending_mutex.lock(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         if (self.is_closed) return error.ConnectionClosed;
 
@@ -270,7 +275,7 @@ pub const ResponseManager = struct {
             }
         }
 
-        var timer = std.time.Timer.start() catch unreachable;
+        var timer = zio.Stopwatch.start();
         while (true) {
             // Look up entry fresh each iteration - previous pointers may be invalid after timedWait
             const entry = self.pending_responses.getEntry(handle.rid) orelse {
@@ -323,7 +328,7 @@ pub const ResponseManager = struct {
                 return error.ConnectionClosed;
             }
 
-            const elapsed = timer.read();
+            const elapsed = timer.read().toNanoseconds();
             if (elapsed >= timeout_ns) {
                 cleanup = true;
                 if (msgs.len > 0) {
@@ -341,7 +346,7 @@ pub const ResponseManager = struct {
             }
 
             // After this call, any entry pointers become invalid due to potential HashMap modifications
-            self.pending_condition.timedWait(&self.pending_mutex, .fromNanoseconds(wait_timeout_ns)) catch {
+            self.pending_condition.waitTimeout(self.io, &self.pending_mutex, nsTimeout(wait_timeout_ns)) catch {
                 // Timeout occurred - return what we have collected so far
                 cleanup = true;
                 if (msgs.len > 0) {
@@ -366,8 +371,8 @@ pub const ResponseManager = struct {
             return;
         };
 
-        try self.pending_mutex.lock();
-        defer self.pending_mutex.unlock();
+        try self.pending_mutex.lock(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         // Don't process responses after shutdown
         if (self.is_closed) return;
@@ -392,7 +397,7 @@ pub const ResponseManager = struct {
             },
         }
 
-        self.pending_condition.broadcast(); // Wake up waiting fibers
+        self.pending_condition.broadcast(self.io); // Wake up waiting fibers
     }
 
     fn extractRid(self: *ResponseManager, subject: []const u8) ?u64 {
@@ -416,7 +421,7 @@ test "response manager basic functionality" {
     const rt = try zio.Runtime.init(allocator, .{});
     defer rt.deinit();
 
-    var manager = ResponseManager.init(allocator);
+    var manager = ResponseManager.init(allocator, rt.io());
     defer manager.deinit();
 
     // Test that we can create request handles with different rids
@@ -438,16 +443,16 @@ test "request handle timeout functionality" {
     const rt = try zio.Runtime.init(allocator, .{});
     defer rt.deinit();
 
-    var manager = ResponseManager.init(allocator);
+    var manager = ResponseManager.init(allocator, rt.io());
     defer manager.deinit();
 
     const handle = try manager.createRequest();
     defer manager.cleanupRequest(handle);
 
     // Test timeout behavior
-    const start = std.time.nanoTimestamp();
+    var timer = zio.Stopwatch.start();
     const result = manager.waitForResponse(handle, 1_000_000); // 1ms timeout
-    const duration = std.time.nanoTimestamp() - start;
+    const duration = timer.read().toNanoseconds();
 
     try testing.expectError(error.Timeout, result);
     try testing.expect(duration >= 1_000_000); // At least 1ms passed
@@ -460,7 +465,7 @@ test "multi-response request creation and timeout" {
     const rt = try zio.Runtime.init(allocator, .{});
     defer rt.deinit();
 
-    var manager = ResponseManager.init(allocator);
+    var manager = ResponseManager.init(allocator, rt.io());
     defer manager.deinit();
 
     // Test that we can create multi-response request handles

--- a/src/root.zig
+++ b/src/root.zig
@@ -78,6 +78,7 @@ pub const Result = @import("result.zig").Result;
 pub const ObjectStore = @import("jetstream_objstore.zig").ObjectStore;
 pub const ObjectStoreManager = @import("jetstream_objstore.zig").ObjectStoreManager;
 pub const ObjectMeta = @import("jetstream_objstore.zig").ObjectMeta;
+pub const SliceReader = @import("jetstream_objstore.zig").SliceReader;
 pub const ObjectInfo = @import("jetstream_objstore.zig").ObjectInfo;
 pub const ObjectStoreConfig = @import("jetstream_objstore.zig").ObjectStoreConfig;
 pub const ObjectStoreError = @import("jetstream_objstore.zig").ObjectStoreError;

--- a/src/server_pool.zig
+++ b/src/server_pool.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const zio = @import("zio");
 const ArrayList = std.ArrayList;
 const StringArrayHashMapUnmanaged = std.StringArrayHashMapUnmanaged;
 const Url = @import("url.zig").Url;
@@ -160,7 +161,7 @@ pub const ServerPool = struct {
     pub fn shuffle(self: *ServerPool, offset: usize) void {
         if (self.servers.count() <= offset + 1) return;
 
-        var prng = std.rand.DefaultPrng.init(@bitCast(std.time.nanoTimestamp()));
+        var prng = std.Random.DefaultPrng.init(@intCast(zio.Timestamp.now(.monotonic).toNanoseconds()));
         const random = prng.random();
 
         // Shuffle the underlying entries directly
@@ -176,7 +177,7 @@ pub const ServerPool = struct {
 };
 
 test "server pool basic operations" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -203,7 +204,7 @@ test "server pool basic operations" {
 }
 
 test "server pool duplicate prevention" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -230,7 +231,7 @@ test "server pool duplicate prevention" {
 }
 
 test "server removal on max reconnects" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -13,6 +13,9 @@
 
 const std = @import("std");
 const zio = @import("zio");
+const xsync = @import("xsync");
+const Io = std.Io;
+const msTimeout = @import("io_util.zig").msTimeout;
 const Allocator = std.mem.Allocator;
 const Message = @import("message.zig").Message;
 const RefCounter = @import("ref_counter.zig").RefCounter;
@@ -64,7 +67,7 @@ pub const Subscription = struct {
 
     // Drain state
     draining: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
-    drain_complete: zio.ResetEvent = .init,
+    drain_complete: xsync.Event = .init,
 
     pub const MessageQueue = ConcurrentQueue(*Message, 1024); // 1K chunk size
 
@@ -83,7 +86,7 @@ pub const Subscription = struct {
             .sid = sid,
             .subject = subject_copy,
             .queue = queue_group_copy,
-            .messages = MessageQueue.init(nc.allocator, .{}),
+            .messages = MessageQueue.init(nc.allocator, nc.io, .{}),
             .handler = handler,
         };
 
@@ -226,9 +229,9 @@ pub const Subscription = struct {
 
         if (timeout_ms == 0) {
             // No timeout - wait indefinitely
-            try self.drain_complete.wait();
+            try self.drain_complete.wait(self.nc.io);
         } else {
-            try self.drain_complete.timedWait(.fromMilliseconds(timeout_ms));
+            try self.drain_complete.waitTimeout(self.nc.io, msTimeout(timeout_ms));
         }
     }
 
@@ -258,7 +261,7 @@ pub const Subscription = struct {
         self.max_msgs.store(max, .release);
     }
 
-    pub fn nextMsg(self: *Subscription, timeout_ms: u64) (zio.Cancelable || error{Timeout})!*Message {
+    pub fn nextMsg(self: *Subscription, timeout_ms: u64) (Io.Cancelable || error{Timeout})!*Message {
         // Check if subscription has reached autounsubscribe limit
         const max = self.max_msgs.load(.acquire);
         if (max > 0 and self.delivered_msgs.load(.acquire) >= max) {
@@ -339,7 +342,7 @@ pub fn decrementPending(sub: *Subscription, msg_size: usize) void {
     // Check if drain is complete (we just decremented from 1 to 0)
     if (sub.draining.load(.acquire) and remaining_msgs == 1) {
         log.debug("Subscription {d} drain completed", .{sub.sid});
-        sub.drain_complete.set();
+        sub.drain_complete.set(sub.nc.io);
         sub.nc.notifySubscriptionDrainComplete();
     }
 }

--- a/src/url.zig
+++ b/src/url.zig
@@ -166,7 +166,7 @@ pub const Url = struct {
 };
 
 test "url parsing without scheme" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -180,7 +180,7 @@ test "url parsing without scheme" {
 }
 
 test "url parsing with scheme" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -193,7 +193,7 @@ test "url parsing with scheme" {
 }
 
 test "url parsing with user info" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -208,7 +208,7 @@ test "url parsing with user info" {
 }
 
 test "url parsing discovered servers" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -14,14 +14,18 @@ pub const std_options = std.Options{
 const std = @import("std");
 const builtin = @import("builtin");
 
+const Io = std.Io;
 const Allocator = std.mem.Allocator;
 
 const BORDER = "=" ** 80;
 
-// Log capture for suppressing logs in passing tests
+// Log capture for suppressing logs in passing tests.
+// The Io is stashed at startup so the global log callback can perform mutex
+// operations without having to thread `Io` through every call site.
 const LogCapture = struct {
     capture_writer: ?*std.Io.Writer = null,
-    mutex: std.Thread.Mutex = .{},
+    mutex: Io.Mutex = .init,
+    io: ?Io = null,
 
     pub fn logFn(
         self: *@This(),
@@ -30,8 +34,14 @@ const LogCapture = struct {
         comptime format: []const u8,
         args: anytype,
     ) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = self.io orelse {
+            // No Io available yet — fall back to raw stderr.
+            const scope_prefix = "(" ++ @tagName(scope) ++ "/" ++ @tagName(level) ++ "): ";
+            std.debug.print(scope_prefix ++ format ++ "\n", args);
+            return;
+        };
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         const scope_prefix = "(" ++ @tagName(scope) ++ "/" ++ @tagName(level) ++ "): ";
 
@@ -39,20 +49,20 @@ const LogCapture = struct {
             // Write to capture buffer
             writer.print(scope_prefix ++ format ++ "\n", args) catch return;
         } else {
-            // Write to stderr (no locking needed, std.debug.print handles it)
+            // Write to stderr (std.debug.print handles its own locking)
             std.debug.print(scope_prefix ++ format ++ "\n", args);
         }
     }
 
-    pub fn startCapture(self: *@This(), writer: *std.Io.Writer) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn startCapture(self: *@This(), io: Io, writer: *std.Io.Writer) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         self.capture_writer = writer;
     }
 
-    pub fn stopCapture(self: *@This()) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn stopCapture(self: *@This(), io: Io) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         self.capture_writer = null;
     }
 };
@@ -71,25 +81,29 @@ pub fn customLogFn(
 // use in custom panic handler
 var current_test: ?[]const u8 = null;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const gpa = init.gpa;
 
-    const allocator = gpa.allocator();
+    log_capture.io = io;
+    defer log_capture.io = null;
 
-    var env = Env.init(allocator);
-    defer env.deinit(allocator);
+    var env = Env.init(gpa, init.environ_map);
+    defer env.deinit(gpa);
 
-    var slowest = SlowTracker.init(allocator, 5);
-    defer slowest.deinit();
+    var slowest = SlowTracker.init(io, 5);
+    defer slowest.deinit(gpa);
 
     var pass: usize = 0;
     var fail: usize = 0;
     var skip: usize = 0;
     var leak: usize = 0;
 
-    var log_buffer: std.Io.Writer.Allocating = .init(allocator);
+    var log_buffer: std.Io.Writer.Allocating = .init(gpa);
     defer log_buffer.deinit();
+
+    var failed_tests: std.ArrayList([]const u8) = .empty;
+    defer failed_tests.deinit(gpa);
 
     Printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
 
@@ -102,13 +116,42 @@ pub fn main() !void {
         }
     }
 
+    // Count total tests to run
+    const test_count = blk: {
+        var count: usize = 0;
+        for (builtin.test_functions) |t| {
+            if (isSetup(t) or isTeardown(t)) continue;
+            const is_unnamed_test = isUnnamed(t);
+            if (env.filters.items.len > 0) {
+                if (is_unnamed_test) continue;
+                var matches = false;
+                for (env.filters.items) |f| {
+                    if (std.mem.indexOf(u8, t.name, f) != null) {
+                        matches = true;
+                        break;
+                    }
+                }
+                if (!matches) continue;
+            }
+            count += 1;
+        }
+        break :blk count;
+    };
+
+    const root_node = if (env.verbose == .off) std.Progress.start(io, .{
+        .root_name = "Running tests",
+        .estimated_total_items = test_count,
+    }) else std.Progress.Node.none;
+
+    var test_index: usize = 0;
+
     for (builtin.test_functions) |t| {
         if (isSetup(t) or isTeardown(t)) {
             continue;
         }
 
         var status = Status.pass;
-        slowest.startTiming();
+        slowest.startTiming(io);
 
         const is_unnamed_test = isUnnamed(t);
         if (env.filters.items.len > 0) {
@@ -129,29 +172,46 @@ pub fn main() !void {
 
         const friendly_name = t.name;
 
+        // Update progress
+        if (root_node.index != .none) {
+            root_node.setCompletedItems(test_index);
+            // Progress truncates at 40 chars, so show the end of long names
+            const display_name = if (friendly_name.len <= std.Progress.Node.max_name_len)
+                friendly_name
+            else
+                friendly_name[friendly_name.len - std.Progress.Node.max_name_len ..];
+            root_node.setName(display_name);
+        }
+
+        test_index += 1;
+
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
+        std.testing.io_instance = .init(gpa, .{});
 
         if (env.do_log_capture) {
             log_buffer.clearRetainingCapacity();
-            log_capture.startCapture(&log_buffer.writer);
+            log_capture.startCapture(io, &log_buffer.writer);
         }
 
         // Print test name before running (for debugging hangs)
-        if (env.verbose) {
-            Printer.fmt("{s} .. ", .{friendly_name});
+        switch (env.verbose) {
+            .naming => Printer.fmt("{s} .. ", .{friendly_name}),
+            .tracing => Printer.fmt("{s}\n", .{friendly_name}),
+            .off => {},
         }
 
         const result = t.func();
 
         if (env.do_log_capture) {
-            log_capture.stopCapture();
+            log_capture.stopCapture(io);
         }
 
         current_test = null;
 
-        const ns_taken = slowest.endTiming(friendly_name);
+        const ns_taken = slowest.endTiming(io, gpa, friendly_name);
 
+        std.testing.io_instance.deinit();
         if (std.testing.allocator_instance.deinit() == .leak) {
             leak += 1;
             Printer.status(.fail, "\n{s}\n\"{s}\" - Memory Leak\n{s}\n", .{ BORDER, friendly_name, BORDER });
@@ -169,6 +229,7 @@ pub fn main() !void {
                 status = .fail;
                 fail += 1;
                 fail_err = err;
+                failed_tests.append(gpa, friendly_name) catch {};
             },
         }
 
@@ -179,16 +240,20 @@ pub fn main() !void {
             .skip => "SKIP",
             .text => "",
         };
-        if (env.verbose) {
-            Printer.status(status, "{s}", .{status_str});
-            Printer.fmt(" ({d:.2}ms)\n", .{ms});
-        } else if (status == .fail) {
-            Printer.fmt("{s} .. ", .{friendly_name});
-            Printer.status(status, "{s}", .{status_str});
-            Printer.fmt(" ({d:.2}ms)\n", .{ms});
+        switch (env.verbose) {
+            .naming => {
+                Printer.status(status, "{s}", .{status_str});
+                Printer.fmt(" ({d:.2}ms)\n", .{ms});
+            },
+            .tracing => {
+                Printer.fmt("  ", .{});
+                Printer.status(status, "{s}", .{status_str});
+                Printer.fmt(" ({d:.2}ms)\n", .{ms});
+            },
+            .off => {},
         }
 
-        // Print error details after the status line
+        // Print error details for failures (in non-verbose mode, progress will show above this)
         if (fail_err) |err| {
             Printer.fmt("{s}\n", .{BORDER});
             Printer.status(.fail, "\"{s}\" - {s}\n", .{ friendly_name, @errorName(err) });
@@ -200,11 +265,7 @@ pub fn main() !void {
 
             Printer.fmt("{s}\n", .{BORDER});
             if (@errorReturnTrace()) |trace| {
-                if (builtin.zig_version.major == 0 and builtin.zig_version.minor < 16) {
-                    std.debug.dumpStackTrace(trace.*);
-                } else {
-                    std.debug.dumpStackTrace(trace);
-                }
+                std.debug.dumpErrorReturnTrace(trace);
             }
             if (env.fail_first) {
                 break;
@@ -221,6 +282,11 @@ pub fn main() !void {
         }
     }
 
+    // End progress before printing summary
+    if (root_node.index != .none) {
+        root_node.end();
+    }
+
     const total_tests = pass + fail;
     const status = if (fail == 0) Status.pass else Status.fail;
     Printer.status(status, "\n{d} of {d} test{s} passed\n", .{ pass, total_tests, if (total_tests != 1) "s" else "" });
@@ -230,10 +296,17 @@ pub fn main() !void {
     if (leak > 0) {
         Printer.status(.fail, "{d} test{s} leaked\n", .{ leak, if (leak != 1) "s" else "" });
     }
+    if (failed_tests.items.len > 0) {
+        Printer.fmt("\n", .{});
+        Printer.fmt("Failed tests:\n", .{});
+        for (failed_tests.items) |name| {
+            Printer.fmt("  {s}\n", .{name});
+        }
+    }
     Printer.fmt("\n", .{});
     try slowest.display();
     Printer.fmt("\n", .{});
-    std.posix.exit(if (fail == 0) 0 else 1);
+    std.process.exit(if (fail == 0) 0 else 1);
 }
 
 const Printer = struct {
@@ -263,16 +336,13 @@ const SlowTracker = struct {
     const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
     max: usize,
     slowest: SlowestQueue,
-    timer: std.time.Timer,
+    started: Io.Clock.Timestamp,
 
-    fn init(allocator: Allocator, count: u32) SlowTracker {
-        const timer = std.time.Timer.start() catch @panic("failed to start timer");
-        var slowest = SlowestQueue.init(allocator, {});
-        slowest.ensureTotalCapacity(count) catch @panic("OOM");
+    fn init(io: Io, count: u32) SlowTracker {
         return .{
             .max = count,
-            .timer = timer,
-            .slowest = slowest,
+            .started = .now(io, .awake),
+            .slowest = SlowestQueue.initContext({}),
         };
     }
 
@@ -281,24 +351,24 @@ const SlowTracker = struct {
         name: []const u8,
     };
 
-    fn deinit(self: SlowTracker) void {
-        self.slowest.deinit();
+    fn deinit(self: *SlowTracker, allocator: Allocator) void {
+        self.slowest.deinit(allocator);
     }
 
-    fn startTiming(self: *SlowTracker) void {
-        self.timer.reset();
+    fn startTiming(self: *SlowTracker, io: Io) void {
+        self.started = .now(io, .awake);
     }
 
-    fn endTiming(self: *SlowTracker, test_name: []const u8) u64 {
-        var timer = self.timer;
-        const ns = timer.lap();
+    fn endTiming(self: *SlowTracker, io: Io, allocator: Allocator, test_name: []const u8) u64 {
+        const now = Io.Clock.Timestamp.now(io, .awake);
+        const ns: u64 = @intCast(self.started.durationTo(now).raw.nanoseconds);
 
         var slowest = &self.slowest;
 
         if (slowest.count() < self.max) {
             // Capacity is fixed to the # of slow tests we want to track
             // If we've tracked fewer tests than this capacity, than always add
-            slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+            slowest.push(allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
             return ns;
         }
 
@@ -313,8 +383,8 @@ const SlowTracker = struct {
         }
 
         // the previous fastest of our slow tests, has been pushed off.
-        _ = slowest.removeMin();
-        slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+        _ = slowest.popMin();
+        slowest.push(allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
         return ns;
     }
 
@@ -322,7 +392,7 @@ const SlowTracker = struct {
         var slowest = self.slowest;
         const count = slowest.count();
         Printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
-        while (slowest.removeMinOrNull()) |info| {
+        while (slowest.popMin()) |info| {
             const ms = @as(f64, @floatFromInt(info.ns)) / 1_000_000.0;
             Printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
         }
@@ -335,17 +405,17 @@ const SlowTracker = struct {
 };
 
 const Env = struct {
-    verbose: bool,
+    const Verbose = enum { off, naming, tracing };
+
+    verbose: Verbose,
     fail_first: bool,
     filters: std.ArrayList([]const u8),
     do_log_capture: bool,
 
-    fn init(allocator: Allocator) Env {
+    fn init(allocator: Allocator, environ_map: *std.process.Environ.Map) Env {
         var filters: std.ArrayList([]const u8) = .empty;
 
-        if (readEnv(allocator, "TEST_FILTER")) |filter_str| {
-            defer allocator.free(filter_str);
-
+        if (environ_map.get("TEST_FILTER")) |filter_str| {
             var iter = std.mem.splitScalar(u8, filter_str, '|');
             while (iter.next()) |part| {
                 const trimmed = std.mem.trim(u8, part, " \t");
@@ -357,10 +427,10 @@ const Env = struct {
         }
 
         return .{
-            .verbose = readEnvBool(allocator, "TEST_VERBOSE", false),
-            .fail_first = readEnvBool(allocator, "TEST_FAIL_FIRST", false),
+            .verbose = readEnvVerbose(environ_map),
+            .fail_first = readEnvBool(environ_map, "TEST_FAIL_FIRST", false),
             .filters = filters,
-            .do_log_capture = readEnvBool(allocator, "TEST_LOG_CAPTURE", true),
+            .do_log_capture = readEnvBool(environ_map, "TEST_LOG_CAPTURE", true),
         };
     }
 
@@ -371,21 +441,16 @@ const Env = struct {
         self.filters.deinit(allocator);
     }
 
-    fn readEnv(allocator: Allocator, key: []const u8) ?[]const u8 {
-        const v = std.process.getEnvVarOwned(allocator, key) catch |err| {
-            if (err == error.EnvironmentVariableNotFound) {
-                return null;
-            }
-            std.log.warn("failed to get env var {s} due to err {}", .{ key, err });
-            return null;
-        };
-        return v;
+    fn readEnvBool(environ_map: *std.process.Environ.Map, key: []const u8, deflt: bool) bool {
+        const value = environ_map.get(key) orelse return deflt;
+        return std.ascii.eqlIgnoreCase(value, "true");
     }
 
-    fn readEnvBool(allocator: Allocator, key: []const u8, deflt: bool) bool {
-        const value = readEnv(allocator, key) orelse return deflt;
-        defer allocator.free(value);
-        return std.ascii.eqlIgnoreCase(value, "true");
+    fn readEnvVerbose(environ_map: *std.process.Environ.Map) Verbose {
+        const value = environ_map.get("TEST_VERBOSE") orelse return .off;
+        if (std.ascii.eqlIgnoreCase(value, "2")) return .tracing;
+        if (std.ascii.eqlIgnoreCase(value, "true") or std.ascii.eqlIgnoreCase(value, "1")) return .naming;
+        return .off;
     }
 };
 

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -32,7 +32,7 @@ test {
 }
 
 test "tests:beforeEach" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -40,7 +40,7 @@ test "tests:beforeEach" {
 }
 
 test "tests:beforeAll" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -48,7 +48,7 @@ test "tests:beforeAll" {
 }
 
 test "tests:afterAll" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/tests/auth_test.zig
+++ b/tests/auth_test.zig
@@ -14,7 +14,7 @@ test "token authentication success" {
         .token = "test_token_123",
     };
 
-    const conn = try utils.createConnection(.token_auth, opts);
+    const conn = try utils.createConnection(rt.io(), .token_auth, opts);
     defer utils.closeConnection(conn);
 
     // If we reach here, authentication succeeded
@@ -38,7 +38,7 @@ test "token handler authentication" {
         .token_handler = TestTokenHandler.getToken,
     };
 
-    const conn = try utils.createConnection(.token_auth, opts);
+    const conn = try utils.createConnection(rt.io(), .token_auth, opts);
     defer utils.closeConnection(conn);
 
     // If we reach here, the token handler was called and authentication succeeded
@@ -63,7 +63,7 @@ test "token handler takes precedence over static token" {
     };
 
     // Should succeed because handler returns valid token
-    const conn = try utils.createConnection(.token_auth, opts);
+    const conn = try utils.createConnection(rt.io(), .token_auth, opts);
     defer utils.closeConnection(conn);
 
     // Authentication succeeded, proving handler took precedence
@@ -82,7 +82,7 @@ test "token authentication failure" {
     };
 
     // This should fail with AuthFailed error
-    const result = utils.createConnection(.token_auth, opts);
+    const result = utils.createConnection(rt.io(), .token_auth, opts);
 
     if (result) |conn| {
         defer utils.closeConnection(conn);
@@ -103,7 +103,7 @@ test "no authentication options against auth server" {
     // Test connection without token to auth server (should fail)
     const opts = nats.ConnectionOptions{};
 
-    const result = utils.createConnection(.token_auth, opts);
+    const result = utils.createConnection(rt.io(), .token_auth, opts);
 
     if (result) |conn| {
         defer utils.closeConnection(conn);

--- a/tests/autounsubscribe_test.zig
+++ b/tests/autounsubscribe_test.zig
@@ -8,7 +8,7 @@ test "autounsubscribe sync basic functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const sub = try conn.subscribeSync("auto.test");
@@ -44,10 +44,10 @@ test "autounsubscribe async basic functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
-    var messages_received = std.ArrayList(*Message){};
+    var messages_received = std.ArrayList(*Message).empty;
     defer {
         for (messages_received.items) |msg| {
             msg.deinit();
@@ -85,9 +85,9 @@ test "autounsubscribe async basic functionality" {
     try conn.flush();
 
     // Wait for message processing with bounded wait loop
-    const deadline_ms = std.time.milliTimestamp() + 1000;
+    var wait_timer = zio.Stopwatch.start();
     var count: usize = 0;
-    while (std.time.milliTimestamp() < deadline_ms) {
+    while (wait_timer.read().toMilliseconds() < 1000) {
         try ctx.mutex.lock();
         count = messages_received.items.len;
         ctx.mutex.unlock();
@@ -102,7 +102,7 @@ test "autounsubscribe error conditions" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const sub = try conn.subscribeSync("error.test");
@@ -126,7 +126,7 @@ test "autounsubscribe delivered message counter" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const sub = try conn.subscribeSync("counter.test");
@@ -182,7 +182,7 @@ test "autounsubscribe with reconnection" {
 
     ReconnectTracker.reset();
 
-    const conn = try utils.createConnection(.node1, .{
+    const conn = try utils.createConnection(rt.io(), .node1, .{
         .reconnect = .{
             .allow_reconnect = true,
             .reconnect_wait_ms = 100,
@@ -221,9 +221,9 @@ test "autounsubscribe with reconnection" {
     try conn.reconnect();
 
     // Wait for reconnection to complete
-    var timer = try std.time.Timer.start();
+    var timer = zio.Stopwatch.start();
     while (ReconnectTracker.reconnected_called == 0) {
-        if (timer.read() >= 5000 * std.time.ns_per_ms) {
+        if (timer.read().toNanoseconds() >= 5000 * std.time.ns_per_ms) {
             return error.ReconnectionTimeout;
         }
         try rt.sleep(.fromMilliseconds(10));

--- a/tests/callbacks_test.zig
+++ b/tests/callbacks_test.zig
@@ -21,7 +21,7 @@ test "close callback" {
 
     counts.reset();
 
-    const conn = try utils.createConnection(.node1, .{
+    const conn = try utils.createConnection(rt.io(), .node1, .{
         .callbacks = .{
             .closed_cb = struct {
                 fn close(_: *nats.Connection) void {

--- a/tests/core_request_reply_test.zig
+++ b/tests/core_request_reply_test.zig
@@ -35,7 +35,7 @@ test "basic request reply" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const replier_sub = try conn.subscribe("test.echo", echoHandler, .{conn});
@@ -56,7 +56,7 @@ test "simple request reply functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create a replier that echoes back the request
@@ -77,7 +77,7 @@ test "concurrent request reply" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create echo handler
@@ -110,7 +110,7 @@ test "request with no responders" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Send a request to a subject with no responder - should return NoResponders error
@@ -124,7 +124,7 @@ test "request timeout with no responder" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Set up a handler that never responds
@@ -144,7 +144,7 @@ test "request with different subjects" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Set up multiple echo handlers on different subjects
@@ -170,7 +170,7 @@ test "requestMsg basic functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create echo handler
@@ -197,7 +197,7 @@ test "requestMsg with headers" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create handler that echoes back with headers
@@ -228,7 +228,7 @@ test "requestMsg validation errors" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var request_msg = try conn.newMsg();
@@ -259,7 +259,7 @@ test "requestMany with max_messages" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Set up handler that sends multiple responses
@@ -283,7 +283,7 @@ test "requestMany with timeout collecting all" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Set up handler that sends multiple responses
@@ -323,7 +323,7 @@ test "requestMany with sentinel function" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Set up handler that sends responses with sentinel
@@ -359,7 +359,7 @@ test "requestMany with no responders" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const result = conn.requestMany("test.no.responder.many", "no one", 100, .{});
@@ -370,7 +370,7 @@ test "requestMany with stall timeout" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Set up sync subscription to handle the request manually

--- a/tests/drain_test.zig
+++ b/tests/drain_test.zig
@@ -7,7 +7,7 @@ test "subscription drain sync - immediate completion" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create sync subscription
@@ -33,7 +33,7 @@ test "subscription drain sync - with pending messages" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create sync subscription
@@ -91,7 +91,7 @@ test "subscription drain async - with callback processing" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var messages_processed: u32 = 0;
@@ -160,7 +160,7 @@ test "subscription drain blocks new messages" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create sync subscription
@@ -204,7 +204,7 @@ test "subscription drain timeout" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create sync subscription and leave one message unconsumed
@@ -229,7 +229,7 @@ test "subscription drain not draining error" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const sub = try conn.subscribeSync("test.drain.not_draining");
@@ -244,7 +244,7 @@ test "connection drain - no subscriptions" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Initially not draining
@@ -261,7 +261,7 @@ test "connection drain - single subscription" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create subscription with pending messages
@@ -302,7 +302,7 @@ test "connection drain - multiple subscriptions" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create multiple subscriptions
@@ -353,7 +353,7 @@ test "connection drain - already draining" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // First drain call
@@ -369,7 +369,7 @@ test "connection drain not draining error" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Should error if not draining

--- a/tests/headers_test.zig
+++ b/tests/headers_test.zig
@@ -9,7 +9,7 @@ test "publish and receive message with headers" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create a subscription
@@ -52,7 +52,7 @@ test "publish message without headers using publishMsg" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create a subscription
@@ -122,7 +122,7 @@ test "message with reply and headers" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create a subscription

--- a/tests/jetstream_delete_msg_test.zig
+++ b/tests/jetstream_delete_msg_test.zig
@@ -8,7 +8,7 @@ test "delete message" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -60,7 +60,7 @@ test "erase message" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -112,7 +112,7 @@ test "delete vs erase message behavior" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -167,7 +167,7 @@ test "delete message error cases" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -207,7 +207,7 @@ test "erase message error cases" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_duplicate_ack_test.zig
+++ b/tests/jetstream_duplicate_ack_test.zig
@@ -10,7 +10,7 @@ test "ack should succeed on first call" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -90,7 +90,7 @@ test "ack should fail on second call" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -179,7 +179,7 @@ test "nak should fail after ack" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -268,7 +268,7 @@ test "inProgress can be called multiple times" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_get_msg_direct_test.zig
+++ b/tests/jetstream_get_msg_direct_test.zig
@@ -8,7 +8,7 @@ test "get message by sequence with direct API" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -51,7 +51,7 @@ test "get last message by subject with direct API" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -108,7 +108,7 @@ test "get next message by subject with direct API" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -164,7 +164,7 @@ test "get message with headers using direct API" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -231,7 +231,7 @@ test "direct API without allow_direct should fail" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -264,7 +264,7 @@ test "direct API error cases" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_get_msg_test.zig
+++ b/tests/jetstream_get_msg_test.zig
@@ -8,7 +8,7 @@ test "get message by sequence" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -53,7 +53,7 @@ test "get last message by subject" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -111,7 +111,7 @@ test "get next message by subject" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -178,7 +178,7 @@ test "get message with headers" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -232,7 +232,7 @@ test "message operations error cases" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -272,7 +272,7 @@ test "invalid option combinations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -306,7 +306,7 @@ test "getMsgs stub returns not implemented" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_kv_history_test.zig
+++ b/tests/jetstream_kv_history_test.zig
@@ -21,7 +21,7 @@ test "KV history retrieval" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -67,7 +67,7 @@ test "KV keys listing" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -116,7 +116,7 @@ test "KV keys with filters" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -164,7 +164,7 @@ test "KV watch basic functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_kv_simple_test.zig
+++ b/tests/jetstream_kv_simple_test.zig
@@ -8,7 +8,7 @@ test "KV simple put and get" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_kv_test.zig
+++ b/tests/jetstream_kv_test.zig
@@ -10,7 +10,7 @@ test "KV basic create bucket" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -40,7 +40,7 @@ test "KV put and get operations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -81,7 +81,7 @@ test "KV create and update operations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -127,7 +127,7 @@ test "KV delete operation" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -170,7 +170,7 @@ test "KV purge operation" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -210,7 +210,7 @@ test "KV status operation" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_large_list_test.zig
+++ b/tests/jetstream_large_list_test.zig
@@ -10,7 +10,7 @@ test "create many streams and list them" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -75,7 +75,7 @@ test "stress test: create 20 streams and list them" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_nak_test.zig
+++ b/tests/jetstream_nak_test.zig
@@ -10,7 +10,7 @@ test "NAK redelivery with delivery count verification" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -35,8 +35,8 @@ test "NAK redelivery with delivery count verification" {
 
         fn init(allocator: std.mem.Allocator) @This() {
             return .{
-                .messages = std.ArrayList([]const u8){},
-                .delivery_counts = std.ArrayList(u64){},
+                .messages = std.ArrayList([]const u8).empty,
+                .delivery_counts = std.ArrayList(u64).empty,
                 .allocator = allocator,
             };
         }
@@ -152,7 +152,7 @@ test "NAK with max delivery limit" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -252,7 +252,7 @@ test "JetStream message metadata parsing" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -347,7 +347,7 @@ test "NAK with delay redelivery timing" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -372,7 +372,7 @@ test "NAK with delay redelivery timing" {
 
         fn init(allocator: std.mem.Allocator) @This() {
             return .{
-                .delivery_times = std.ArrayList(i64){},
+                .delivery_times = std.ArrayList(i64).empty,
                 .allocator = allocator,
             };
         }
@@ -393,7 +393,7 @@ test "NAK with delay redelivery timing" {
             data.mutex.lockUncancelable();
             defer data.mutex.unlock();
 
-            const current_time = std.time.milliTimestamp();
+            const current_time: i64 = @intCast(@divTrunc(zio.Timestamp.now(.monotonic).toNanoseconds(), std.time.ns_per_ms));
             data.delivery_times.append(data.allocator, current_time) catch return;
 
             const delivery_count = js_msg.metadata.num_delivered;
@@ -469,7 +469,7 @@ test "NAK with zero delay behaves like regular NAK" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_objstore_streaming_test.zig
+++ b/tests/jetstream_objstore_streaming_test.zig
@@ -8,7 +8,7 @@ test "ObjectStore streaming put and get" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create JetStream context
@@ -41,8 +41,8 @@ test "ObjectStore streaming put and get" {
         .opts = null,
     };
 
-    var stream = std.io.fixedBufferStream(test_data);
-    const put_result = try store.put(meta, stream.reader());
+    var stream = nats.SliceReader{ .data = test_data };
+    const put_result = try store.put(meta, &stream);
 
     try testing.expect(put_result.value.size == test_data.len);
     try testing.expect(put_result.value.chunks > 0);
@@ -81,7 +81,7 @@ test "ObjectStore streaming empty object" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create JetStream context
@@ -114,8 +114,8 @@ test "ObjectStore streaming empty object" {
         .opts = null,
     };
 
-    var stream = std.io.fixedBufferStream(empty_data);
-    const put_result = try store.put(meta, stream.reader());
+    var stream = nats.SliceReader{ .data = empty_data };
+    const put_result = try store.put(meta, &stream);
 
     try testing.expect(put_result.value.size == 0);
     try testing.expect(put_result.value.chunks == 0);

--- a/tests/jetstream_objstore_test.zig
+++ b/tests/jetstream_objstore_test.zig
@@ -10,7 +10,7 @@ test "ObjectStore basic create store" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});
@@ -39,7 +39,7 @@ test "ObjectStore put and get operations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});
@@ -90,7 +90,7 @@ test "ObjectStore chunked operations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});
@@ -141,7 +141,7 @@ test "ObjectStore delete operations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});
@@ -189,7 +189,7 @@ test "ObjectStore list operations" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});
@@ -260,7 +260,7 @@ test "ObjectStore validation" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Test store name validation
@@ -284,7 +284,7 @@ test "ObjectStore error handling" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});

--- a/tests/jetstream_pull_test.zig
+++ b/tests/jetstream_pull_test.zig
@@ -16,7 +16,7 @@ test "JetStream pull consumer basic fetch" {
     defer rt.deinit();
 
     // Use existing utility functions
-    const nc = try utils.createDefaultConnection();
+    const nc = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(nc);
 
     var js = nc.jetstream(.{});

--- a/tests/jetstream_push_test.zig
+++ b/tests/jetstream_push_test.zig
@@ -10,7 +10,7 @@ test "basic push subscription" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -69,7 +69,7 @@ test "push subscription with flow control" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -131,7 +131,7 @@ test "push subscription error handling" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_stream_purge_test.zig
+++ b/tests/jetstream_stream_purge_test.zig
@@ -8,7 +8,7 @@ test "purge stream" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -42,7 +42,7 @@ test "purge stream with filter" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -78,7 +78,7 @@ test "purge stream with sequence limit" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -114,7 +114,7 @@ test "purge stream with keep parameter" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_stream_test.zig
+++ b/tests/jetstream_stream_test.zig
@@ -10,7 +10,7 @@ test "list stream names" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -52,7 +52,7 @@ test "add stream" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -90,7 +90,7 @@ test "list streams" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -138,7 +138,7 @@ test "update stream" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -182,7 +182,7 @@ test "delete stream" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -236,7 +236,7 @@ test "get stream info" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -10,7 +10,7 @@ test "JetStream synchronous subscription basic functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -52,7 +52,7 @@ test "JetStream synchronous subscription timeout" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -74,9 +74,9 @@ test "JetStream synchronous subscription timeout" {
     defer sync_sub.deinit();
 
     // Test timeout (should return error.Timeout after timeout)
-    const start = std.time.milliTimestamp();
+    var timer = zio.Stopwatch.start();
     const result = sync_sub.nextMsg(100); // 100ms timeout
-    const duration = std.time.milliTimestamp() - start;
+    const duration = timer.read().toMilliseconds();
 
     try testing.expectError(error.Timeout, result);
     try testing.expect(duration >= 100); // Should have waited at least 100ms
@@ -88,7 +88,7 @@ test "JetStream synchronous subscription multiple messages" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -133,7 +133,7 @@ test "JetStream synchronous queue subscription basic functionality" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/jetstream_test.zig
+++ b/tests/jetstream_test.zig
@@ -10,7 +10,7 @@ test "connect" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const js = conn.jetstream(.{});
@@ -21,7 +21,7 @@ test "get account info" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -37,7 +37,7 @@ test "add consumer" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -77,7 +77,7 @@ test "list consumer names" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -128,7 +128,7 @@ test "list consumers" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -182,7 +182,7 @@ test "get consumer info" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -227,7 +227,7 @@ test "delete consumer" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -293,7 +293,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     // Create JetStream context
@@ -377,7 +377,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     var js = conn.jetstreamDefault();
@@ -447,7 +447,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     var js = conn.jetstreamDefault();
@@ -534,7 +534,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     var js = conn.jetstreamDefault();
@@ -575,7 +575,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     var js = conn.jetstreamDefault();
@@ -599,7 +599,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     var js = conn.jetstreamDefault();
@@ -627,7 +627,7 @@ test "delete consumer" {
 //     const rt = try zio.Runtime.init(std.testing.allocator, .{});
 //     defer rt.deinit();
 
-//     const conn = try utils.createDefaultConnection();
+//     const conn = try utils.createDefaultConnection(rt.io());
 //     defer utils.closeConnection(conn);
 
 //     var js = conn.jetstreamDefault();
@@ -687,7 +687,7 @@ test "JetStream publish basic message" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -725,7 +725,7 @@ test "JetStream publish with message deduplication" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -770,7 +770,7 @@ test "JetStream publish with expected sequence" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -808,7 +808,7 @@ test "JetStream publish with expected last subject sequence" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});
@@ -847,7 +847,7 @@ test "JetStream publishMsg with pre-constructed message" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var js = conn.jetstream(.{});

--- a/tests/minimal_test.zig
+++ b/tests/minimal_test.zig
@@ -9,7 +9,7 @@ test "connect" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = try utils.createDefaultConnection();
+    const conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 }
 
@@ -17,7 +17,7 @@ test "connect wrong port" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const conn = utils.createConnectionWrongPort() catch return;
+    const conn = utils.createConnectionWrongPort(rt.io()) catch return;
     defer utils.closeConnection(conn);
 
     try std.testing.expect(false);
@@ -27,7 +27,7 @@ test "basic publish and subscribe" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create a subscription
@@ -50,7 +50,7 @@ test "async subscribe" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Message handler function

--- a/tests/pending_msgs_test.zig
+++ b/tests/pending_msgs_test.zig
@@ -7,7 +7,7 @@ test "pending_msgs counter sync subscription" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     // Create sync subscription
@@ -72,7 +72,7 @@ test "pending_msgs counter async subscription" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var message_count = std.atomic.Value(u32).init(0);

--- a/tests/reconnection_test.zig
+++ b/tests/reconnection_test.zig
@@ -60,9 +60,9 @@ const CallbackTracker = struct {
         try self.mutex.lock();
         defer self.mutex.unlock();
 
-        var timer = try std.time.Timer.start();
+        var timer = zio.Stopwatch.start();
         while (self.disconnected_called == 0) {
-            if (timer.read() >= timeout_ms * std.time.ns_per_ms) {
+            if (timer.read().toNanoseconds() >= timeout_ms * std.time.ns_per_ms) {
                 return error.DisconnectTimeout;
             }
             self.cond.timedWait(&self.mutex, .fromMilliseconds(100)) catch {};
@@ -73,9 +73,9 @@ const CallbackTracker = struct {
         try self.mutex.lock();
         defer self.mutex.unlock();
 
-        var timer = try std.time.Timer.start();
+        var timer = zio.Stopwatch.start();
         while (self.reconnected_called == 0) {
-            if (timer.read() >= timeout_ms * std.time.ns_per_ms) {
+            if (timer.read().toNanoseconds() >= timeout_ms * std.time.ns_per_ms) {
                 return error.ReconnectionTimeout;
             }
             self.cond.timedWait(&self.mutex, .fromMilliseconds(100)) catch {};
@@ -89,7 +89,7 @@ test "basic reconnection when server stops" {
 
     tracker.reset();
 
-    const nc = try utils.createConnection(.node1, .{
+    const nc = try utils.createConnection(rt.io(), .node1, .{
         .trace = true,
         .reconnect = .{
             .allow_reconnect = true,
@@ -131,7 +131,7 @@ test "manual reconnection with nc.reconnect()" {
 
     tracker.reset();
 
-    const nc = try utils.createConnection(.node1, .{
+    const nc = try utils.createConnection(rt.io(), .node1, .{
         .trace = true,
         .reconnect = .{
             .allow_reconnect = true,
@@ -193,7 +193,7 @@ test "reconnect() errors when disabled" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const nc = try utils.createConnection(.node1, .{
+    const nc = try utils.createConnection(rt.io(), .node1, .{
         .reconnect = .{
             .allow_reconnect = false,
         },
@@ -208,7 +208,7 @@ test "reconnect() errors when connection closed" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const nc = try utils.createConnection(.node1, .{});
+    const nc = try utils.createConnection(rt.io(), .node1, .{});
     defer utils.closeConnection(nc);
 
     nc.close();

--- a/tests/subscribe_test.zig
+++ b/tests/subscribe_test.zig
@@ -10,7 +10,7 @@ test "subscribeSync smoke test" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const sub = try conn.subscribeSync("test");
@@ -30,7 +30,7 @@ test "queueSubscribeSync smoke test" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     const sub = try conn.queueSubscribeSync("test", "workers");
@@ -68,9 +68,9 @@ const MessageCollector = struct {
         defer self.mutex.unlock();
 
         const timeout_ns = timeout_ms * std.time.ns_per_ms;
-        var timer = std.time.Timer.start() catch unreachable;
+        var timer = zio.Stopwatch.start();
         while (self.result == null) {
-            const elapsed_ns = timer.read();
+            const elapsed_ns = timer.read().toNanoseconds();
             if (elapsed_ns >= timeout_ns) {
                 return error.Timeout;
             }
@@ -84,7 +84,7 @@ test "subscribe smoke test" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var collector: MessageCollector = .{};
@@ -105,7 +105,7 @@ test "queueSubscribe smoke test" {
     const rt = try zio.Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var conn = try utils.createDefaultConnection();
+    var conn = try utils.createDefaultConnection(rt.io());
     defer utils.closeConnection(conn);
 
     var collector: MessageCollector = .{};

--- a/tests/utils.zig
+++ b/tests/utils.zig
@@ -4,6 +4,18 @@ const zio = @import("zio");
 
 const log = std.log.default;
 
+// Blocking `std.Io` instance for test utilities that run outside any zio
+// runtime (docker compose invocations, sleeps). Lazily initialized, never
+// deinitialized; lives for the whole test process.
+var blocking_io_instance: ?std.Io.Threaded = null;
+
+fn blockingIo() std.Io {
+    if (blocking_io_instance == null) {
+        blocking_io_instance = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    }
+    return blocking_io_instance.?.io();
+}
+
 pub const Node = enum(u16) {
     node1 = 14222,
     node2 = 14223,
@@ -12,7 +24,7 @@ pub const Node = enum(u16) {
     unknown = 14226,
 };
 
-pub fn createConnection(node: Node, opts: nats.ConnectionOptions) !*nats.Connection {
+pub fn createConnection(io: std.Io, node: Node, opts: nats.ConnectionOptions) !*nats.Connection {
     const port = @intFromEnum(node);
     const url = try std.fmt.allocPrint(std.testing.allocator, "nats://127.0.0.1:{d}", .{port});
     defer std.testing.allocator.free(url);
@@ -20,7 +32,7 @@ pub fn createConnection(node: Node, opts: nats.ConnectionOptions) !*nats.Connect
     var conn = try std.testing.allocator.create(nats.Connection);
     errdefer std.testing.allocator.destroy(conn);
 
-    conn.* = nats.Connection.init(std.testing.allocator, opts);
+    conn.* = nats.Connection.init(std.testing.allocator, io, opts);
     errdefer conn.deinit();
 
     try conn.connect(url);
@@ -28,12 +40,12 @@ pub fn createConnection(node: Node, opts: nats.ConnectionOptions) !*nats.Connect
     return conn;
 }
 
-pub fn createDefaultConnection() !*nats.Connection {
-    return createConnection(.node1, .{});
+pub fn createDefaultConnection(io: std.Io) !*nats.Connection {
+    return createConnection(io, .node1, .{});
 }
 
-pub fn createConnectionWrongPort() !*nats.Connection {
-    return createConnection(.unknown, .{});
+pub fn createConnectionWrongPort(io: std.Io) !*nats.Connection {
+    return createConnection(io, .unknown, .{});
 }
 
 pub fn closeConnection(conn: *nats.Connection) void {
@@ -41,15 +53,14 @@ pub fn closeConnection(conn: *nats.Connection) void {
     std.testing.allocator.destroy(conn);
 }
 
-pub fn runDockerComposeCapture(allocator: std.mem.Allocator, compose_args: []const []const u8) !std.process.Child.RunResult {
-    var args: std.ArrayListUnmanaged([]const u8) = .{};
+pub fn runDockerComposeCapture(allocator: std.mem.Allocator, compose_args: []const []const u8) !std.process.RunResult {
+    var args: std.ArrayListUnmanaged([]const u8) = .empty;
     defer args.deinit(allocator);
 
     try args.appendSlice(allocator, &.{ "docker", "compose", "-f", "docker-compose.test.yml", "-p", "nats-zig-test" });
     try args.appendSlice(allocator, compose_args);
 
-    return try std.process.Child.run(.{
-        .allocator = allocator,
+    return try std.process.run(allocator, blockingIo(), .{
         .argv = args.items,
     });
 }
@@ -61,9 +72,9 @@ pub fn runDockerCompose(allocator: std.mem.Allocator, compose_args: []const []co
 }
 
 pub fn waitForHealthyServices(allocator: std.mem.Allocator, timeout_ms: i64) !void {
-    const deadline = std.time.milliTimestamp() + timeout_ms;
+    var timer = zio.Stopwatch.start();
     while (true) {
-        if (std.time.milliTimestamp() > deadline) {
+        if (timer.read().toMilliseconds() > @as(u64, @intCast(timeout_ms))) {
             return error.ServicesNotHealthy;
         }
 
@@ -86,14 +97,14 @@ pub fn waitForHealthyServices(allocator: std.mem.Allocator, timeout_ms: i64) !vo
             return;
         }
 
-        std.Thread.sleep(100 * std.time.ns_per_ms);
+        blockingIo().sleep(.fromMilliseconds(100), .awake) catch {};
     }
 }
 
 var global_counter: std.atomic.Value(u64) = std.atomic.Value(u64).init(0);
 
 pub fn generateUniqueName(allocator: std.mem.Allocator, prefix: []const u8) ![]u8 {
-    const timestamp = std.time.microTimestamp();
+    const timestamp = @divTrunc(zio.Timestamp.now(.realtime).toNanoseconds(), std.time.ns_per_us);
     const counter = global_counter.fetchAdd(1, .monotonic);
 
     return std.fmt.allocPrint(allocator, "{s}_{d}_{d}", .{ prefix, timestamp, counter });


### PR DESCRIPTION
First step of the migration to Zig's `std.Io` interface: thread an `Io` instance through the API and replace all zio synchronization primitives with [xsync](https://github.com/lalinsky/xsync.zig) equivalents, which are built on the `std.Io` futex interface and work across `Io` instances. zio remains the runtime underneath (spawning, select, networking) — everything still runs on `rt.io()`.

## API change

```zig
var nc = nats.Connection.init(allocator, rt.io(), .{});
```

`Connection.init` now takes a `std.Io`, stored on the connection and threaded into the write buffers, concurrent queues, response manager, message pool, and subscriptions.

## Primitive swap

- `zio.Mutex` → `xsync.Mutex` (`lock(io)` / `lockUncancelable(io)` / `unlock(io)`)
- `zio.Condition` → `xsync.Condition` (`timedWait` → `waitTimeout(io, &mutex, std.Io.Timeout)`)
- `zio.ResetEvent` → `xsync.Event` for `drain_completion` and subscription `drain_complete`
- **Exception:** `reconnect_requested` stays a `zio.ResetEvent` because it is an operand of the `zio.select` in `runConnection`; it moves in the next step (select → Group + shared exit event)
- Timeout conversion helpers in new `src/io_util.zig`

## Zig 0.16 upgrade

The sync swap requires Zig 0.16, so this also finishes the 0.15 → 0.16 upgrade of the tree:

- `std.time.Timer`/timestamps removed → `zio.Stopwatch` / `zio.Timestamp`
- `std.Thread.Mutex` removed → `std.Io.Mutex` + `Io.Threaded.mutexLock` (nuid, test runner)
- `std.crypto.random` removed → `Io.random` via the global single-threaded Io (nuid)
- `GeneralPurposeAllocator` → `DebugAllocator`; ArrayList `{}` inits → `.empty`
- ArrayList `.writer(allocator)` / `std.io.fixedBufferStream` → `std.Io.Writer.Allocating` / `Writer.fixed`; parser payload writing now tracks a plain position
- `std.process.Child.run` → `std.process.run(gpa, io, ...)` — note `Io.Threaded.global_single_threaded` is unusable for spawning (failing allocator, empty environ), so test utils lazily create a real `Io.Threaded`
- 0.16 build API in `build.zig`; `minimum_zig_version` bumped to 0.16.0

## Other

- Test runner replaced with zio's `std.process.Init`-based runner (same `TEST_*` env vars)
- Dependencies point at proper remotes: zio pinned to a `main` commit (no tag has the 0.16 vtable work yet), xsync at `v1.0.0`
- `src/request_reply_test.zig` turned out to be dead code (never imported, pre-refactor Subscription API); left untouched

## Testing

`./check.sh` fully green with the fetched remote dependencies: `zig fmt`, 41/41 unit tests, 135/135 e2e tests against Docker-composed NATS servers. Examples and benchmarks build.

## Next steps

1. Replace the `zio.select` in `runConnection` with a Group + shared exit event (removes the last `zio.ResetEvent`)
2. Audit cancel-swallowing sites (`waitTimeout(...) catch {}` in `flush()`/handshake) for `std.Io` cancel-once semantics / `recancel()`
3. Eventually swap `zio.net` for `std.Io` networking (blocked upstream: only `Io.Threaded` implements TCP in 0.16.0)