### PR TITLE
Migrate task spawning to the std.Io interface

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -288,8 +288,8 @@ pub const Connection = struct {
     handshake_error: ?anyerror = null,
     handshake_cond: xsync.Condition = .init,
 
-    // Connection manager fiber (owns reader/flusher tasks)
-    manager_task: zio.Group = .init,
+    // Connection manager task (owns reader/flusher tasks)
+    manager_task: Io.Group = .init,
 
     // Main connection mutex (protects most fields)
     mutex: xsync.Mutex = .init,
@@ -397,8 +397,8 @@ pub const Connection = struct {
 
         _ = try self.server_pool.addServer(url, false);
 
-        try self.manager_task.spawn(managerLoop, .{self});
-        errdefer self.manager_task.cancel();
+        try self.manager_task.concurrent(self.io, managerTask, .{self});
+        errdefer self.manager_task.cancel(self.io);
 
         while (true) {
             switch (self.status) {
@@ -437,7 +437,7 @@ pub const Connection = struct {
 
         log.info("Closing connection", .{});
 
-        self.manager_task.cancel();
+        self.manager_task.cancel(self.io);
 
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
@@ -904,6 +904,15 @@ pub const Connection = struct {
         return messages;
     }
 
+    /// Group task wrapper: `Io.Group` task return types must coerce to
+    /// `Cancelable!void`, so any other error is logged here.
+    fn managerTask(self: *Self) Io.Cancelable!void {
+        self.managerLoop() catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+            log.err("Manager loop failed: {}", .{err});
+        };
+    }
+
     fn managerLoop(self: *Self) anyerror!void {
         log.debug("Manager loop started", .{});
         defer log.debug("Manager loop exited", .{});
@@ -964,7 +973,7 @@ pub const Connection = struct {
             if (attempts > 1) {
                 const delay_ms = self.calculateReconnectDelay(attempts - 1);
                 log.debug("Waiting {}ms before reconnection attempt {}", .{ delay_ms, attempts });
-                try zio.sleep(.fromMilliseconds(delay_ms));
+                try self.io.sleep(.fromMilliseconds(@intCast(delay_ms)), .awake);
             }
         }
     }
@@ -1038,11 +1047,11 @@ pub const Connection = struct {
             self.exit_signal = null;
         }
 
-        var reader_task = try zio.spawn(readerLoop, .{ self, &stream, &exit_signal });
-        defer reader_task.cancel();
+        var reader_task = try self.io.concurrent(readerLoop, .{ self, &stream, &exit_signal });
+        defer reader_task.cancel(self.io);
 
-        var flusher_task = try zio.spawn(flusherLoop, .{ self, &stream, &exit_signal });
-        defer flusher_task.cancel();
+        var flusher_task = try self.io.concurrent(flusherLoop, .{ self, &stream, &exit_signal });
+        defer flusher_task.cancel(self.io);
 
         var was_reconnect = false;
 

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -54,8 +54,8 @@ pub const Subscription = struct {
     // Callback support
     handler: ?MsgHandler = null,
 
-    // Handler fiber group (for async subscriptions only)
-    handler_group: zio.Group = .init,
+    // Handler task group (for async subscriptions only)
+    handler_group: Io.Group = .init,
 
     // Track pending messages and bytes for both sync and async subscriptions
     pending_msgs: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
@@ -104,7 +104,7 @@ pub const Subscription = struct {
     pub fn startHandler(self: *Subscription) !void {
         if (self.handler == null) return; // Sync subscription, no handler fiber needed
 
-        try self.handler_group.spawn(handlerLoop, .{self});
+        try self.handler_group.concurrent(self.nc.io, handlerLoop, .{self});
     }
 
     /// Handler fiber loop - waits for messages and calls the handler
@@ -162,8 +162,8 @@ pub const Subscription = struct {
     }
 
     fn destroy(self: *Subscription) void {
-        // Cancel handler fiber group and wait for completion
-        self.handler_group.cancel();
+        // Cancel handler task group and wait for completion
+        self.handler_group.cancel(self.nc.io);
 
         self.nc.allocator.free(self.subject);
 


### PR DESCRIPTION
Stacked on #133 (which is stacked on #132). Moves all task spawning, joining, and cancellation from zio APIs to the `std.Io` interface — zio still executes everything, reached through its `Io` vtable (`rt.io()`), and the same code is now testable against `std.Io.Threaded`.

## Changes

- `manager_task` (Connection) and `handler_group` (Subscription) are `std.Io.Group` instead of `zio.Group`; spawned with `Group.concurrent(io, ...)`, torn down with `Group.cancel(io)` (cancel-and-join, idempotent, group reusable afterwards — matching how `close()`/`connect()` reuse it)
- `Io.Group` task return types must coerce to `Cancelable!void`, so `managerLoop` gains a thin `managerTask` wrapper that propagates `error.Canceled` and logs anything else
- reader/flusher tasks in `runConnection` use `io.concurrent(...)` returning `Io.Future(void)`, with scope-exit `future.cancel(io)` replacing `JoinHandle.cancel` — same teardown ordering (both joined before the exit signal is cleared and the socket closes)
- reconnect backoff sleeps via `io.sleep`

`concurrent` (never `async`) is used for all long-running tasks, since `Io.async` is permitted to run the function inline before returning — an inline reader loop would deadlock. `error.ConcurrencyUnavailable` propagates as a connection error.

## Remaining zio surface after this

- `zio.net` (Stream, tcpConnectToHost, setKeepAlive) + `zio.ev` error sets in `ConnectionError`
- monotonic time helpers (`zio.Stopwatch`, `zio.Timestamp` for PRNG seeds)

Cancellation semantics, sync primitives, spawning, and sleeping are all on the `std.Io` interface now.

## Testing

Full `./check.sh` green: `zig fmt`, 41/41 unit, 135/135 e2e including reconnection and drain suites.