### PR TITLE
Restore reconnect state before reporting the connection as connected

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -791,7 +791,18 @@ pub const Connection = struct {
             writer.print("UNSUB {d}\r\n", .{sid}) catch unreachable; // Will always fit
         }
 
-        try self.write_buffer.append(writer.buffered());
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
+
+        // Route like publishes: while reconnecting the command goes to
+        // pending_buffer so it survives the connection switch (the live
+        // write buffer is per-connection) and is applied after the
+        // restored subscriptions.
+        if (self.status == .reconnecting and self.options.reconnect.allow_reconnect) {
+            try self.pending_buffer.append(writer.buffered());
+        } else {
+            try self.write_buffer.append(writer.buffered());
+        }
     }
 
     pub fn unsubscribe(self: *Self, sub: *Subscription) void {
@@ -1069,6 +1080,15 @@ pub const Connection = struct {
         // Reset parser for clean state
         self.parser.reset();
 
+        // Discard whatever the previous connection left unsent: the head may
+        // even be the tail of a partially written frame (the flusher consumes
+        // byte-wise), so replaying it would corrupt the new protocol stream,
+        // and any stale complete frames would precede our CONNECT. Dropping
+        // unflushed frames on connection loss matches the at-most-once
+        // semantics of the official clients. Publishes made while
+        // reconnecting are preserved separately in pending_buffer.
+        self.write_buffer.reset();
+
         // Reset ping/pong counters for fresh connection
         self.outgoing_pings = 0;
         self.incoming_pongs = 0;
@@ -1134,24 +1154,36 @@ pub const Connection = struct {
         if (self.status == .reconnecting) {
             was_reconnect = true;
         }
-        self.status = .connected;
-        self.status_cond.broadcast(self.io);
         self.mutex.unlock(self.io);
+
+        // Restore subscriptions while the status is still not `connected`:
+        // publishes keep going to pending_buffer, so the server sees our
+        // interest (including the request/reply inbox) before any buffered
+        // publish. Only then move the pending commands into the live buffer
+        // and flip the status - atomically with respect to publishers, so a
+        // new publish can never overtake a buffered one.
+        try self.resendSubscriptions();
+
+        {
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
+            try self.pending_buffer.moveToBuffer(&self.write_buffer);
+            self.status = .connected;
+            self.status_cond.broadcast(self.io);
+        }
 
         attempts.* = 0;
 
         log.info("Connected successfully to {s}", .{server.parsed_url.full_url});
 
-        // Invoke reconnected callback if this is a reconnection
+        // Invoke reconnected callback last, so it observes a connection with
+        // subscriptions restored and buffered publishes already queued ahead
+        // of anything it sends (the flusher writes them out asynchronously).
         if (was_reconnect) {
             if (self.options.callbacks.reconnected_cb) |cb| {
                 cb(self);
             }
         }
-
-        try self.resendSubscriptions();
-
-        try self.pending_buffer.moveToBuffer(&self.write_buffer);
 
         try exit_signal.event.wait(self.io);
 
@@ -1705,14 +1737,17 @@ pub const Connection = struct {
         var to_remove = ArrayList(u64).empty;
         defer to_remove.deinit(self.allocator);
 
+        // Use a local arena rather than the shared scratch arena: scratch is
+        // guarded by the connection mutex, which is not held here, and
+        // publishes may use it concurrently during reconnection.
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+
         {
             self.subs_mutex.lockUncancelable(self.io);
             defer self.subs_mutex.unlock(self.io);
 
-            const allocator = self.scratch.allocator();
-            defer self.resetScratch();
-
-            var buffer: std.Io.Writer.Allocating = .init(allocator);
+            var buffer: std.Io.Writer.Allocating = .init(arena.allocator());
             defer buffer.deinit();
 
             var iter = self.subscriptions.iterator();

--- a/tests/reconnection_test.zig
+++ b/tests/reconnection_test.zig
@@ -187,6 +187,88 @@ test "manual reconnection with nc.reconnect()" {
     }
 }
 
+const PendingFlushTracker = struct {
+    var disconnected: std.atomic.Value(bool) = .init(false);
+    var reconnected: std.atomic.Value(bool) = .init(false);
+
+    fn reset() void {
+        disconnected.store(false, .release);
+        reconnected.store(false, .release);
+    }
+
+    fn disconnectedCallback(_: *nats.Connection) void {
+        disconnected.store(true, .release);
+    }
+
+    fn reconnectedCallback(nc: *nats.Connection) void {
+        // The callback must observe a fully restored connection: this
+        // publish has to arrive after the restored subscription and after
+        // the publishes buffered while the server was down.
+        nc.publish("test.pending.flush", "from-callback") catch |err| {
+            log.err("Publish from reconnected callback failed: {}", .{err});
+        };
+        reconnected.store(true, .release);
+    }
+
+    fn waitFor(io: std.Io, flag: *std.atomic.Value(bool), timeout: std.Io.Duration) !void {
+        const start = std.Io.Timestamp.now(io, .awake);
+        while (!flag.load(.acquire)) {
+            if (start.untilNow(io, .awake).nanoseconds >= timeout.nanoseconds) {
+                return error.CallbackTimeout;
+            }
+            try io.sleep(.fromMilliseconds(50), .awake);
+        }
+    }
+};
+
+test "publishes buffered during reconnect are flushed after restoration" {
+    const io = std.testing.io;
+
+    PendingFlushTracker.reset();
+
+    // The standalone token server has no cluster peers, so the client can
+    // only ever reconnect to this one server; that makes the buffered
+    // publish path deterministic.
+    const nc = try utils.createConnection(io, .token_auth, .{
+        .token = "test_token_123",
+        .reconnect = .{
+            .allow_reconnect = true,
+            .reconnect_wait = .fromMilliseconds(100),
+            .max_reconnect = 300,
+        },
+        .callbacks = .{
+            .disconnected_cb = PendingFlushTracker.disconnectedCallback,
+            .reconnected_cb = PendingFlushTracker.reconnectedCallback,
+        },
+    });
+    defer utils.closeConnection(nc);
+
+    const sub = try nc.subscribeSync("test.pending.flush");
+    defer sub.deinit();
+
+    log.debug("Stopping nats-token-auth", .{});
+    try utils.runDockerCompose(std.testing.allocator, &.{ "stop", "nats-token-auth" });
+    try PendingFlushTracker.waitFor(io, &PendingFlushTracker.disconnected, .fromSeconds(10));
+
+    // These are buffered in pending_buffer while the server is down.
+    try nc.publish("test.pending.flush", "buffered 1");
+    try nc.publish("test.pending.flush", "buffered 2");
+
+    log.debug("Starting nats-token-auth", .{});
+    try utils.runDockerCompose(std.testing.allocator, &.{ "start", "nats-token-auth" });
+    try PendingFlushTracker.waitFor(io, &PendingFlushTracker.reconnected, .fromSeconds(30));
+
+    // All three messages must arrive, in order: the buffered publishes
+    // first (flushed after the subscription was restored), then the
+    // publish made inside the reconnected callback.
+    const expected = [_][]const u8{ "buffered 1", "buffered 2", "from-callback" };
+    for (expected) |want| {
+        const msg = try sub.nextMsgTimeout(utils.ioTimeout(.fromSeconds(5)));
+        defer msg.deinit();
+        try testing.expectEqualStrings(want, msg.data);
+    }
+}
+
 test "reconnect() errors when disabled" {
     const io = std.testing.io;
 


### PR DESCRIPTION
## Summary

Fixes finding #1 from the static review (reconnect restoration ordering and the shared scratch arena race). Stacked on #139, whose queue fix this depends on.

- restore subscriptions while the status is still `reconnecting`, then move pending publishes and flip to `connected` in a single mutex-scoped block, and invoke `reconnected_cb` last — buffered publishes can no longer be overtaken, requests cannot be sent before the response inbox subscription exists, and the callback observes a fully restored connection
- reset the live write buffer per connection: the byte-wise flusher can leave the tail of a partially written frame at the head after a mid-write disconnect, and stale frames would otherwise be replayed ahead of the new CONNECT (protocol corruption); unflushed frames are dropped on connection loss, matching the official clients' at-most-once behavior, while reconnect-time publishes survive via the pending buffer
- route UNSUB through the pending buffer during reconnection so it survives the connection switch
- use a local arena in `resendSubscriptions` instead of the shared scratch arena (cross-lock data race)

New e2e test against the standalone token server (no cluster failover, deterministic path): stop the server, publish while reconnecting, restart, and assert the buffered messages and a message published from inside `reconnected_cb` all arrive, in order. The callback-publish is the sharp assertion: on the old ordering it is sent before the subscription is restored and lost.

## Validation

- `./check.sh` passed (fmt, unit, full e2e)