### PR TITLE
Send keep-alive PINGs on an idle connection

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1686,12 +1686,20 @@ pub const Connection = struct {
 
         const current_time = io_util.now(self.io);
         if (self.ping_time.durationTo(current_time).nanoseconds >= self.options.ping_interval.nanoseconds) {
-            _ = try self.sendPing(true);
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
+
+            // Count the PING as outstanding before it can be written:
+            // processPong resets the counter under the same mutex, so the
+            // PONG can never be processed ahead of the increment. Checking
+            // first also avoids queueing another PING onto a connection
+            // already deemed stale.
             const current_pings = self.pings_out.fetchAdd(1, .monotonic) + 1;
             if (self.options.max_pings_out > 0 and current_pings > self.options.max_pings_out) {
                 log.warn("Stale connection: {} unanswered PINGs", .{current_pings});
                 return error.StaleConnection;
             }
+            _ = try self.sendPing(false);
             self.ping_time = current_time;
         }
     }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1185,7 +1185,25 @@ pub const Connection = struct {
             }
         }
 
-        try exit_signal.event.wait(self.io);
+        // Wait for the connection to end, waking up on the keep-alive
+        // interval to send PINGs. The manager task is otherwise idle while
+        // the connection is up, so it doubles as the heartbeat timer; this
+        // is the only path that sends keep-alive PINGs, so an idle or
+        // half-open connection is detected even when nothing is received.
+        if (self.options.ping_interval.nanoseconds == 0) {
+            try exit_signal.event.wait(self.io);
+        } else {
+            while (true) {
+                exit_signal.event.waitTimeout(self.io, .{ .duration = .{ .raw = self.options.ping_interval, .clock = .awake } }) catch |err| switch (err) {
+                    error.Timeout => {
+                        try self.checkAndSendPing();
+                        continue;
+                    },
+                    error.Canceled => |e| return e,
+                };
+                break;
+            }
+        }
 
         switch (exit_signal.reason.load(.acquire)) {
             .none => unreachable, // the event is only set by signal()
@@ -1244,8 +1262,6 @@ pub const Connection = struct {
             log.debug("Read {} bytes: {s}", .{ data.len, data });
             try self.parser.parse(self, data);
             reader.toss(data.len);
-
-            try self.checkAndSendPing();
         }
     }
 

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -12,6 +12,7 @@ test {
     _ = @import("drain_test.zig");
     _ = @import("core_request_reply_test.zig");
     _ = @import("reconnection_test.zig");
+    _ = @import("keepalive_test.zig");
     _ = @import("jetstream_test.zig");
     _ = @import("jetstream_stream_test.zig");
     _ = @import("jetstream_push_test.zig");

--- a/tests/keepalive_test.zig
+++ b/tests/keepalive_test.zig
@@ -90,7 +90,9 @@ test "idle connection sends keep-alive pings" {
     defer utils.closeConnection(nc);
 
     // Stay completely idle: no publishes, no inbound traffic. The
-    // keep-alive timer alone must produce PINGs.
+    // keep-alive timer alone must produce PINGs. Note this polls
+    // outgoing_pings, the monotonic count of PINGs sent, not pings_out,
+    // the outstanding count that PONG processing resets.
     const start = std.Io.Timestamp.now(io, .awake);
     while (true) {
         if (start.untilNow(io, .awake).nanoseconds > 5 * std.time.ns_per_s) {

--- a/tests/keepalive_test.zig
+++ b/tests/keepalive_test.zig
@@ -4,6 +4,83 @@ const utils = @import("utils.zig");
 
 const testing = std.testing;
 
+// Port for the in-test fake server; outside the range used by the
+// docker-compose servers (14222-14229).
+const fake_server_port = 14239;
+
+/// Accepts one connection, completes the NATS handshake (INFO, then PONG
+/// for the client's handshake PING), and then never responds again while
+/// keeping the socket open and draining input.
+const SilentServer = struct {
+    fn run(io: std.Io, listener: *std.Io.net.Server) void {
+        var stream = listener.accept(io) catch return;
+        defer stream.close(io);
+
+        var read_buf: [4096]u8 = undefined;
+        var write_buf: [256]u8 = undefined;
+        var stream_reader = stream.reader(io, &read_buf);
+        var stream_writer = stream.writer(io, &write_buf);
+        const reader = &stream_reader.interface;
+        const writer = &stream_writer.interface;
+
+        writer.writeAll("INFO {\"max_payload\":1048576}\r\n") catch return;
+        writer.flush() catch return;
+
+        // Answer only the handshake PING, so the client connects fully.
+        handshake: while (true) {
+            const data = reader.buffered();
+            if (std.mem.indexOfScalar(u8, data, '\n')) |i| {
+                const is_ping = std.mem.startsWith(u8, data[0..i], "PING");
+                reader.toss(i + 1);
+                if (is_ping) {
+                    writer.writeAll("PONG\r\n") catch return;
+                    writer.flush() catch return;
+                    break :handshake;
+                }
+                continue;
+            }
+            reader.fillMore() catch return;
+        }
+
+        // Stay silent: drain keep-alive PINGs without ever answering.
+        // (fillMore/toss rather than line reads: takeDelimiterExclusive
+        // keeps returning a delimiter-less tail after EOF instead of
+        // erroring, which would spin here.)
+        while (true) {
+            reader.fillMore() catch return;
+            reader.toss(reader.buffered().len);
+        }
+    }
+};
+
+test "stale connection detected on unresponsive server" {
+    const io = std.testing.io;
+
+    const address: std.Io.net.IpAddress = .{ .ip4 = .loopback(fake_server_port) };
+    var listener = try address.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+
+    var server_task = try io.concurrent(SilentServer.run, .{ io, &listener });
+    defer server_task.cancel(io);
+
+    const url = std.fmt.comptimePrint("nats://127.0.0.1:{d}", .{fake_server_port});
+    const nc = try utils.createConnectionWithUrl(io, url, .{
+        .ping_interval = .fromMilliseconds(100),
+        .max_pings_out = 2,
+    });
+    defer utils.closeConnection(nc);
+
+    // With a 100ms interval and max_pings_out=2, the third unanswered PING
+    // (~300ms) must mark the connection stale and tear it down.
+    const start = std.Io.Timestamp.now(io, .awake);
+    while (nc.status == .connected) {
+        if (start.untilNow(io, .awake).nanoseconds > 5 * std.time.ns_per_s) {
+            return error.StaleNotDetected;
+        }
+        try io.sleep(.fromMilliseconds(50), .awake);
+    }
+}
+
 test "idle connection sends keep-alive pings" {
     const io = std.testing.io;
 

--- a/tests/keepalive_test.zig
+++ b/tests/keepalive_test.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const nats = @import("nats");
+const utils = @import("utils.zig");
+
+const testing = std.testing;
+
+test "idle connection sends keep-alive pings" {
+    const io = std.testing.io;
+
+    const nc = try utils.createConnection(io, .node1, .{
+        .ping_interval = .fromMilliseconds(100),
+    });
+    defer utils.closeConnection(nc);
+
+    // Stay completely idle: no publishes, no inbound traffic. The
+    // keep-alive timer alone must produce PINGs.
+    const start = std.Io.Timestamp.now(io, .awake);
+    while (true) {
+        if (start.untilNow(io, .awake).nanoseconds > 5 * std.time.ns_per_s) {
+            return error.NoKeepAlivePings;
+        }
+        try io.sleep(.fromMilliseconds(50), .awake);
+
+        nc.mutex.lockUncancelable(io);
+        const pings = nc.outgoing_pings;
+        nc.mutex.unlock(io);
+        if (pings >= 3) break;
+    }
+
+    // The server answered them with PONGs, so the connection is still
+    // healthy and usable.
+    try nc.publish("test.keepalive", "still alive");
+    try nc.flush();
+}


### PR DESCRIPTION
## Summary

Finding 2 from the static review: `checkAndSendPing` only ran in the reader loop after inbound data arrived, so a fully idle or half-open connection never sent a PING and `ping_interval` / `max_pings_out` could not detect staleness.

Rather than adding a dedicated heartbeat task, the manager task's idle wait in `runConnection` becomes a timed wait on the exit signal: on each `ping_interval` timeout it runs `checkAndSendPing` and keeps waiting; `error.StaleConnection` propagates through the normal teardown path into reconnection. `ping_interval = 0` keeps the untimed wait (keep-alive disabled). The reader-loop call is removed, which also makes `ping_time` single-task state (it was previously touched from the reader task).

The new e2e test connects with a 100ms interval, stays fully idle, and requires `outgoing_pings` to grow — it fails with `NoKeepAlivePings` on main.

## Validation

- `./check.sh` passed (fmt, unit, full e2e)
- new test verified to fail without the fix