### PR TITLE
Fix ResponseManager shutdown deadlock

### DIFF
--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -81,18 +81,24 @@ pub const ResponseManager = struct {
     }
 
     pub fn deinit(self: *ResponseManager) void {
-        // Signal shutdown and wake up all waiters
+        // Mark the manager closed and detach the subscription under the
+        // lock, but stop the subscription outside of it: sub.deinit() joins
+        // the response handler task, and the handler acquires pending_mutex,
+        // so holding it across the join can deadlock. Once is_closed is set,
+        // a still-running handler drops any response it delivers.
         self.pending_mutex.lockUncancelable(self.io);
-        defer self.pending_mutex.unlock(self.io);
+        self.is_closed = true;
+        const resp_mux = self.resp_mux;
+        self.resp_mux = null;
+        self.pending_condition.broadcast(self.io); // Wake up all waiters
+        self.pending_mutex.unlock(self.io);
 
-        // Clean up the response subscription if it exists
-        if (self.resp_mux) |sub| {
+        if (resp_mux) |sub| {
             sub.deinit(); // This will unsubscribe and release the user reference
-            self.resp_mux = null;
         }
 
-        self.is_closed = true;
-        self.pending_condition.broadcast(self.io); // Wake up all waiters
+        self.pending_mutex.lockUncancelable(self.io);
+        defer self.pending_mutex.unlock(self.io);
 
         // Clean up any remaining pending responses
         if (self.pending_responses.count() > 0) {

--- a/tests/core_request_reply_test.zig
+++ b/tests/core_request_reply_test.zig
@@ -402,7 +402,7 @@ test "requestMany with stall timeout" {
     try std.testing.expectEqual(2, messages.len);
 }
 
-test "close connection with requests in flight" {
+test "close connection with responses in flight" {
     const io = std.testing.io;
 
     // Responder on its own connection, so replies keep flowing while the
@@ -414,7 +414,13 @@ test "close connection with requests in flight" {
         fn handle(msg: *nats.Message, conn: *nats.Connection) !void {
             defer msg.deinit();
             const reply_subject = msg.reply orelse return;
-            try conn.publish(reply_subject, msg.data);
+            // Send a burst of replies per request: the requester consumes
+            // the first one, and the surplus keeps the response handler
+            // acquiring pending_mutex (via the unknown-rid path) while the
+            // connection is torn down.
+            for (0..20) |_| {
+                try conn.publish(reply_subject, msg.data);
+            }
         }
     };
     const responder_sub = try responder_conn.subscribe("test.inflight.echo", EchoHandler.handle, .{responder_conn});
@@ -437,9 +443,9 @@ test "close connection with requests in flight" {
     };
 
     // Repeatedly tear down a connection while its response multiplexer is
-    // busy: replies queued before the reader stops are still dispatched by
-    // the response handler while ResponseManager.deinit runs. This used to
-    // be able to deadlock (deinit joined the handler while holding the
+    // busy: the surplus replies are still streaming in and being dispatched
+    // by the response handler while ResponseManager.deinit runs. This used
+    // to be able to deadlock (deinit joined the handler while holding the
     // mutex the handler needs).
     for (0..5) |_| {
         const conn = try utils.createDefaultConnection(io);

--- a/tests/core_request_reply_test.zig
+++ b/tests/core_request_reply_test.zig
@@ -401,3 +401,61 @@ test "requestMany with stall timeout" {
     // Should get exactly 2 messages before stall timeout
     try std.testing.expectEqual(2, messages.len);
 }
+
+test "close connection with requests in flight" {
+    const io = std.testing.io;
+
+    // Responder on its own connection, so replies keep flowing while the
+    // requesting connection is torn down.
+    const responder_conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(responder_conn);
+
+    const EchoHandler = struct {
+        fn handle(msg: *nats.Message, conn: *nats.Connection) !void {
+            defer msg.deinit();
+            const reply_subject = msg.reply orelse return;
+            try conn.publish(reply_subject, msg.data);
+        }
+    };
+    const responder_sub = try responder_conn.subscribe("test.inflight.echo", EchoHandler.handle, .{responder_conn});
+    defer responder_sub.deinit();
+    try responder_conn.flush();
+
+    const Requester = struct {
+        var stop: std.atomic.Value(bool) = .init(false);
+
+        fn run(conn: *nats.Connection) void {
+            while (!stop.load(.acquire)) {
+                const reply = conn.request(
+                    "test.inflight.echo",
+                    "ping",
+                    .{ .duration = .{ .raw = .fromMilliseconds(500), .clock = .awake } },
+                ) catch return;
+                reply.deinit();
+            }
+        }
+    };
+
+    // Repeatedly tear down a connection while its response multiplexer is
+    // busy: replies queued before the reader stops are still dispatched by
+    // the response handler while ResponseManager.deinit runs. This used to
+    // be able to deadlock (deinit joined the handler while holding the
+    // mutex the handler needs).
+    for (0..5) |_| {
+        const conn = try utils.createDefaultConnection(io);
+
+        Requester.stop.store(false, .release);
+        var group: std.Io.Group = .init;
+        for (0..4) |_| {
+            try group.concurrent(io, Requester.run, .{conn});
+        }
+
+        io.sleep(.fromMilliseconds(30), .awake) catch {};
+
+        // Let requesters wind down, then tear down the connection while
+        // late replies are still being processed.
+        Requester.stop.store(true, .release);
+        try group.await(io);
+        utils.closeConnection(conn);
+    }
+}


### PR DESCRIPTION
## Summary

Finding 3 from the static review: `ResponseManager.deinit` held `pending_mutex` while `sub.deinit()` canceled and joined the response handler task — which acquires `pending_mutex` to deliver responses. Holding a lock across a join with a task that takes the same lock is a deadlock pattern; it is defused today only by cancelation delivery (every cancelation point in the response handler propagates `error.Canceled`, and subscription teardown closes the message queue first), so this is **hardening against the pattern**, not a fix for a currently reproducible hang — any future `catch` swallowing cancelation in that path would have armed it.

The restructure: mark closed and detach `resp_mux` under the lock, broadcast to waiters, unlock, stop the subscription outside the lock (a still-running handler acquires the mutex, sees `is_closed`, and drops the response), then relock for the final pending-response cleanup.

The e2e test tears a connection down repeatedly while the response multiplexer is kept busy: the responder sends a burst of replies per request, the requester consumes the first, and the surplus keeps the handler acquiring `pending_mutex` (unknown-rid path) during `deinit`. Verified honest: the test also passes against the pre-fix code (per the above), so it serves as a teardown-under-load regression test rather than a deadlock reproducer.

## Validation

- `./check.sh` passed (fmt, unit, full e2e)
- stress test run repeatedly against both fixed and unfixed code, stable
