### PR TITLE
Make Object Store wire format compatible with ADR-20

### DIFF
--- a/src/jetstream_objstore.zig
+++ b/src/jetstream_objstore.zig
@@ -55,6 +55,27 @@ pub const SliceReader = struct {
 // Default chunk size (128KB)
 const DEFAULT_CHUNK_SIZE: u32 = 128 * 1024;
 
+// Digest format per ADR-20: "SHA-256=<base64url of the hash>". The base64
+// alphabet is URL-safe *with* padding, matching base64.URLEncoding in the
+// reference Go client.
+const digest_prefix = "SHA-256=";
+const base64url = std.base64.url_safe;
+const digest_text_len = digest_prefix.len + base64url.Encoder.calcSize(std.crypto.hash.sha2.Sha256.digest_length);
+
+fn digestText(hash: [std.crypto.hash.sha2.Sha256.digest_length]u8, out: *[digest_text_len]u8) []const u8 {
+    @memcpy(out[0..digest_prefix.len], digest_prefix);
+    _ = base64url.Encoder.encode(out[digest_prefix.len..], &hash);
+    return out;
+}
+
+/// Object names are unrestricted, so they are base64url-encoded (with
+/// padding) to form the meta message subject token, per ADR-20.
+fn encodeName(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    const buf = try allocator.alloc(u8, base64url.Encoder.calcSize(name.len));
+    _ = base64url.Encoder.encode(buf, name);
+    return buf;
+}
+
 // Object Store-specific errors
 pub const ObjectStoreError = error{
     StoreNotFound,
@@ -64,10 +85,10 @@ pub const ObjectStoreError = error{
     BadRequest,
 };
 
-/// Object metadata options
+/// Object metadata options. Field names match the ADR-20 JSON schema.
 pub const ObjectMetaOptions = struct {
     /// Custom chunk size for this object
-    chunk_size: ?u32 = null,
+    max_chunk_size: ?u32 = null,
 };
 
 /// Object metadata structure
@@ -104,18 +125,30 @@ pub const ObjectInfo = struct {
     deleted: bool = false,
 };
 
-/// ObjectInfo for JSON serialization (excludes mtime)
+/// ObjectInfo for JSON serialization, matching the ADR-20 schema (mtime is
+/// never stored; it is taken from the message timestamp when reading).
+/// Official clients omit empty fields (a tombstone has no "digest" key), so
+/// everything that can be absent has a default, and parsing must ignore
+/// unknown fields ("mtime", "headers", "metadata", ...).
 const ObjectInfoJson = struct {
     name: []const u8,
     description: ?[]const u8 = null,
-    opts: ?ObjectMetaOptions = null,
+    options: ?ObjectMetaOptions = null,
     bucket: []const u8,
     nuid: []const u8,
-    size: u64,
-    chunks: u32,
-    digest: []const u8,
+    size: u64 = 0,
+    chunks: u32 = 0,
+    digest: []const u8 = "",
     deleted: bool = false,
 };
+
+// alloc_always: parsed strings must be copies owned by the caller's arena,
+// not slices into the transient message payload.
+const info_json_parse_options: std.json.ParseOptions = .{
+    .ignore_unknown_fields = true,
+    .allocate = .alloc_always,
+};
+const info_json_stringify_options: std.json.Stringify.Options = .{ .emit_null_optional_fields = false };
 
 /// Configuration for creating object stores
 pub const ObjectStoreConfig = struct {
@@ -123,8 +156,6 @@ pub const ObjectStoreConfig = struct {
     store_name: []const u8,
     /// Description of the store
     description: ?[]const u8 = null,
-    /// Maximum object size in bytes (-1 = unlimited)
-    max_object_size: i64 = -1,
     /// Maximum store size in bytes (-1 = unlimited)
     max_bytes: i64 = -1,
     /// Storage type
@@ -237,12 +268,10 @@ pub const ObjectResult = struct {
 
     /// Verify the complete object integrity
     pub fn verify(self: *ObjectResult) !void {
-        const calculated_digest = self.digest.finalResult();
-        var digest_hex: [64]u8 = undefined;
-        const hex_digest = std.fmt.bytesToHex(calculated_digest, .lower);
-        @memcpy(&digest_hex, &hex_digest);
+        var digest_buf: [digest_text_len]u8 = undefined;
+        const calculated = digestText(self.digest.finalResult(), &digest_buf);
 
-        if (!std.mem.eql(u8, &digest_hex, self.info.digest)) {
+        if (!std.mem.eql(u8, calculated, self.info.digest)) {
             return ObjectStoreError.DigestMismatch;
         }
     }
@@ -302,9 +331,35 @@ pub const ObjectStore = struct {
         self.allocator.free(self.meta_subject_prefix);
     }
 
-    /// Get the meta subject for an object name
+    /// Get the meta subject for an object name; the name is base64url
+    /// encoded per ADR-20 since object names are unrestricted.
     fn getMetaSubject(self: *ObjectStore, object_name: []const u8) ![]u8 {
-        return std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.meta_subject_prefix, object_name });
+        const encoded_name = try encodeName(self.allocator, object_name);
+        defer self.allocator.free(encoded_name);
+        return std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.meta_subject_prefix, encoded_name });
+    }
+
+    /// Purge all chunk messages belonging to an object id.
+    fn purgeChunks(self: *ObjectStore, object_nuid: []const u8) !void {
+        const chunk_subject = try self.getChunkSubject(object_nuid);
+        defer self.allocator.free(chunk_subject);
+
+        const result = try self.js.purgeStream(self.stream_name, .{ .filter = chunk_subject });
+        result.deinit();
+    }
+
+    /// Publish an ObjectInfo JSON to the meta subject with the rollup
+    /// header, so only the latest info message is retained per subject.
+    fn publishMetaJson(self: *ObjectStore, meta_subject: []const u8, info_json: []const u8) !void {
+        const msg = try self.js.nc.newMsg();
+        defer msg.deinit();
+
+        try msg.setSubject(meta_subject, true);
+        try msg.setPayload(info_json, true);
+        try msg.headerSet("Nats-Rollup", "sub");
+
+        const ack = try self.js.publishMsg(msg, .{});
+        ack.deinit();
     }
 
     /// Get the chunk subject for an object NUID
@@ -324,15 +379,36 @@ pub const ObjectStore = struct {
 
         const arena_allocator = arena.allocator();
 
-        // Generate unique identifier for this object - owned by arena
+        // Generate unique identifier for this object - owned by arena.
+        // A fresh nuid is used even when the name is re-used, so the new
+        // chunks go to a new subject.
         const object_nuid = try nuid.nextString(arena_allocator);
+
+        // Look up an existing object with this name (including a deleted
+        // one), so its chunks can be purged after a successful replace.
+        var existing_nuid: ?[]u8 = null;
+        defer if (existing_nuid) |n| self.allocator.free(n);
+        var existing_deleted = false;
+        if (self.infoIncludingDeleted(meta.name)) |existing| {
+            defer existing.deinit();
+            existing_nuid = try self.allocator.dupe(u8, existing.value.nuid);
+            existing_deleted = existing.value.deleted;
+        } else |err| {
+            if (err != ObjectStoreError.ObjectNotFound) return err;
+        }
+
+        // From here on, any failure must clean up the chunks already
+        // published under the new nuid.
+        errdefer self.purgeChunks(object_nuid) catch |purge_err| {
+            log.warn("Failed to clean up partial object upload: {}", .{purge_err});
+        };
 
         // Initialize digest calculation
         var hasher = std.crypto.hash.sha2.Sha256.init(.{});
 
-        // Determine chunk size (use meta.opts.chunk_size or store default)
+        // Determine chunk size (use meta option or store default)
         const chunk_size = if (meta.opts) |opts|
-            opts.chunk_size orelse self.chunk_size
+            opts.max_chunk_size orelse self.chunk_size
         else
             self.chunk_size;
 
@@ -365,9 +441,8 @@ pub const ObjectStore = struct {
         }
 
         // Create digest string - owned by arena
-        const digest_bytes = hasher.finalResult();
-        const hex_digest = std.fmt.bytesToHex(digest_bytes, .lower);
-        const digest_hex = try arena_allocator.dupe(u8, &hex_digest);
+        var digest_buf: [digest_text_len]u8 = undefined;
+        const digest = try arena_allocator.dupe(u8, digestText(hasher.finalResult(), &digest_buf));
 
         const obj_info = ObjectInfo{
             .name = try arena_allocator.dupe(u8, meta.name),
@@ -377,19 +452,28 @@ pub const ObjectStore = struct {
             .nuid = object_nuid,
             .size = total_size,
             .chunks = chunk_count,
-            .digest = digest_hex,
+            .digest = digest,
             .deleted = false,
         };
 
-        // Store metadata
+        // Store metadata (rolled up per subject)
         const info_json = try self.serializeObjectInfo(obj_info);
         defer self.allocator.free(info_json);
 
         const meta_subject = try self.getMetaSubject(meta.name);
         defer self.allocator.free(meta_subject);
 
-        const meta_ack = try self.js.publish(meta_subject, info_json, .{});
-        defer meta_ack.deinit();
+        try self.publishMetaJson(meta_subject, info_json);
+
+        // The object was replaced: purge the chunks of its predecessor
+        // (a deleted predecessor had its chunks purged already).
+        if (existing_nuid) |old_nuid| {
+            if (!existing_deleted) {
+                self.purgeChunks(old_nuid) catch |err| {
+                    log.warn("Failed to purge chunks of replaced object: {}", .{err});
+                };
+            }
+        }
 
         return Result(ObjectInfo){
             .arena = arena,
@@ -407,7 +491,7 @@ pub const ObjectStore = struct {
             .name = object_name,
             .description = null,
             .opts = ObjectMetaOptions{
-                .chunk_size = self.chunk_size,
+                .max_chunk_size = self.chunk_size,
             },
         };
 
@@ -437,13 +521,13 @@ pub const ObjectStore = struct {
         const arena_allocator = arena.allocator();
 
         // Parse object info JSON using arena allocator
-        const parsed = try std.json.parseFromSlice(ObjectInfoJson, arena_allocator, meta_msg.data, .{});
+        const parsed = try std.json.parseFromSlice(ObjectInfoJson, arena_allocator, meta_msg.data, info_json_parse_options);
 
         // Convert from JSON version to full ObjectInfo with proper string ownership
         const obj_info = ObjectInfo{
             .name = parsed.value.name,
             .description = parsed.value.description,
-            .opts = parsed.value.opts,
+            .opts = parsed.value.options,
             .bucket = parsed.value.bucket,
             .nuid = parsed.value.nuid,
             .size = parsed.value.size,
@@ -531,8 +615,19 @@ pub const ObjectStore = struct {
         };
     }
 
-    /// Get object metadata
+    /// Get object metadata. Deleted objects are treated as not found.
     pub fn info(self: *ObjectStore, object_name: []const u8) !Result(ObjectInfo) {
+        const result = try self.infoIncludingDeleted(object_name);
+        errdefer result.deinit();
+
+        if (result.value.deleted) {
+            return ObjectStoreError.ObjectNotFound;
+        }
+        return result;
+    }
+
+    /// Get object metadata, including tombstones of deleted objects.
+    fn infoIncludingDeleted(self: *ObjectStore, object_name: []const u8) !Result(ObjectInfo) {
         try validation.validateOSObjectName(object_name);
 
         const meta_subject = try self.getMetaSubject(object_name);
@@ -551,13 +646,13 @@ pub const ObjectStore = struct {
         const arena_allocator = arena.allocator();
 
         // Parse object info JSON using arena allocator
-        const parsed = try std.json.parseFromSlice(ObjectInfoJson, arena_allocator, meta_msg.data, .{});
+        const parsed = try std.json.parseFromSlice(ObjectInfoJson, arena_allocator, meta_msg.data, info_json_parse_options);
 
         // Convert from JSON version to full ObjectInfo with proper string ownership
         const obj_info = ObjectInfo{
             .name = parsed.value.name,
             .description = parsed.value.description,
-            .opts = parsed.value.opts,
+            .opts = parsed.value.options,
             .bucket = parsed.value.bucket,
             .nuid = parsed.value.nuid,
             .size = parsed.value.size,
@@ -576,26 +671,24 @@ pub const ObjectStore = struct {
         };
     }
 
-    /// Delete an object (marks as deleted)
+    /// Delete an object: write a rolled-up tombstone with zeroed instance
+    /// fields, then purge the object's chunks.
     pub fn delete(self: *ObjectStore, object_name: []const u8) !void {
-        // Get current metadata
+        // Get current metadata; a deleted object is reported as not found.
         const info_result = try self.info(object_name);
         defer info_result.deinit();
         const obj_info = info_result.value;
 
-        if (obj_info.deleted) {
-            return ObjectStoreError.ObjectNotFound;
-        }
-
-        // Create updated object info with deleted flag
+        // Tombstone per ADR-20: meta is kept, instance fields are zeroed.
         const updated_info = ObjectInfo{
-            .name = object_name,
+            .name = obj_info.name,
             .description = obj_info.description,
+            .opts = obj_info.opts,
             .bucket = self.store_name,
             .nuid = obj_info.nuid,
-            .size = obj_info.size,
-            .chunks = obj_info.chunks,
-            .digest = obj_info.digest,
+            .size = 0,
+            .chunks = 0,
+            .digest = "",
             .deleted = true,
         };
 
@@ -606,8 +699,10 @@ pub const ObjectStore = struct {
         const meta_subject = try self.getMetaSubject(object_name);
         defer self.allocator.free(meta_subject);
 
-        const result = try self.js.publish(meta_subject, info_json, .{});
-        defer result.deinit();
+        try self.publishMetaJson(meta_subject, info_json);
+
+        // Reclaim the object's data
+        try self.purgeChunks(obj_info.nuid);
     }
 
     /// List all objects in the store
@@ -653,7 +748,7 @@ pub const ObjectStore = struct {
             defer js_msg.deinit();
 
             // Parse metadata using temporary allocator
-            const parsed = try std.json.parseFromSlice(ObjectInfoJson, self.allocator, js_msg.msg.data, .{});
+            const parsed = try std.json.parseFromSlice(ObjectInfoJson, self.allocator, js_msg.msg.data, info_json_parse_options);
             defer parsed.deinit();
             const meta = parsed.value;
 
@@ -662,7 +757,7 @@ pub const ObjectStore = struct {
                 const obj_info = ObjectInfo{
                     .name = try arena_allocator.dupe(u8, meta.name),
                     .description = if (meta.description) |desc| try arena_allocator.dupe(u8, desc) else null,
-                    .opts = meta.opts,
+                    .opts = meta.options,
                     .bucket = try arena_allocator.dupe(u8, meta.bucket),
                     .nuid = try arena_allocator.dupe(u8, meta.nuid),
                     .size = meta.size,
@@ -693,7 +788,7 @@ pub const ObjectStore = struct {
         const json_info = ObjectInfoJson{
             .name = obj_info.name,
             .description = obj_info.description,
-            .opts = obj_info.opts,
+            .options = obj_info.opts,
             .bucket = obj_info.bucket,
             .nuid = obj_info.nuid,
             .size = obj_info.size,
@@ -701,7 +796,7 @@ pub const ObjectStore = struct {
             .digest = obj_info.digest,
             .deleted = obj_info.deleted,
         };
-        return jsonStringifyAlloc(self.allocator, json_info, .{});
+        return jsonStringifyAlloc(self.allocator, json_info, info_json_stringify_options);
     }
 };
 
@@ -735,7 +830,6 @@ pub const ObjectStoreManager = struct {
             .description = config.description,
             .subjects = &.{ chunk_subject, meta_subject },
             .retention = .limits,
-            .max_msg_size = @intCast(config.max_object_size),
             .max_bytes = config.max_bytes,
             .storage = switch (config.storage) {
                 .file => .file,
@@ -786,10 +880,8 @@ test "validation delegates to validation.zig" {
     try std.testing.expectError(error.InvalidOSBucketName, validation.validateOSBucketName("foo bar"));
     try std.testing.expectError(error.InvalidOSBucketName, validation.validateOSBucketName("foo.bar"));
 
+    // Object names are unrestricted per ADR-20; only empty is invalid.
     try validation.validateOSObjectName("valid-object/name_123.txt");
+    try validation.validateOSObjectName("any name with spaces & symbols!");
     try std.testing.expectError(error.InvalidOSObjectName, validation.validateOSObjectName(""));
-    try std.testing.expectError(error.InvalidOSObjectName, validation.validateOSObjectName("/starts-with-slash"));
-    try std.testing.expectError(error.InvalidOSObjectName, validation.validateOSObjectName("ends-with-slash/"));
-    try std.testing.expectError(error.InvalidOSObjectName, validation.validateOSObjectName(".starts-with-dot"));
-    try std.testing.expectError(error.InvalidOSObjectName, validation.validateOSObjectName("ends-with-dot."));
 }

--- a/src/jetstream_objstore.zig
+++ b/src/jetstream_objstore.zig
@@ -119,7 +119,7 @@ pub const ObjectInfo = struct {
     chunks: u32,
     /// Last modified time (from message timestamp, not stored in JSON)
     mtime: std.Io.Timestamp = .zero,
-    /// SHA-256 digest hex string
+    /// Digest in the ADR-20 format: "SHA-256=<base64url of the hash>"
     digest: []const u8,
     /// True if object is deleted
     deleted: bool = false,
@@ -406,11 +406,18 @@ pub const ObjectStore = struct {
         // Initialize digest calculation
         var hasher = std.crypto.hash.sha2.Sha256.init(.{});
 
-        // Determine chunk size (use meta option or store default)
-        const chunk_size = if (meta.opts) |opts|
+        // Determine chunk size: object option, then store default, with
+        // zero meaning "use the default", matching the reference client.
+        const requested_chunk_size = if (meta.opts) |opts|
             opts.max_chunk_size orelse self.chunk_size
         else
             self.chunk_size;
+        const chunk_size = if (requested_chunk_size != 0)
+            requested_chunk_size
+        else if (self.chunk_size != 0)
+            self.chunk_size
+        else
+            DEFAULT_CHUNK_SIZE;
 
         // Allocate chunk buffer using temporary allocator
         const chunk_buffer = try self.allocator.alloc(u8, chunk_size);
@@ -432,9 +439,10 @@ pub const ObjectStore = struct {
             // Update digest
             hasher.update(chunk_buffer[0..bytes_read]);
 
-            // Publish chunk
+            // Publish chunk; the ack is released immediately, only the
+            // publish success matters here.
             const ack = try self.js.publish(chunk_subject, chunk_buffer[0..bytes_read], .{});
-            defer ack.deinit();
+            ack.deinit();
 
             total_size += bytes_read;
             chunk_count += 1;
@@ -674,8 +682,10 @@ pub const ObjectStore = struct {
     /// Delete an object: write a rolled-up tombstone with zeroed instance
     /// fields, then purge the object's chunks.
     pub fn delete(self: *ObjectStore, object_name: []const u8) !void {
-        // Get current metadata; a deleted object is reported as not found.
-        const info_result = try self.info(object_name);
+        // Look at the current metadata including tombstones: if an earlier
+        // delete wrote the tombstone but failed to purge the chunks,
+        // retrying must be able to finish the cleanup (nats.go behavior).
+        const info_result = try self.infoIncludingDeleted(object_name);
         defer info_result.deinit();
         const obj_info = info_result.value;
 

--- a/src/validation.zig
+++ b/src/validation.zig
@@ -222,27 +222,10 @@ pub fn validateOSBucketName(name: []const u8) !void {
 
 /// Validate Object Store object name according to ADR-6: limited-term with dots, no leading/trailing slashes or dots
 pub fn validateOSObjectName(name: []const u8) !void {
+    // Object names are unrestricted per ADR-20 (they are base64url-encoded
+    // to form the meta message subject); only an empty name is invalid.
     if (name.len == 0) {
         return error.InvalidOSObjectName;
-    }
-
-    if (name.len > 255) {
-        return error.InvalidOSObjectName;
-    }
-
-    // Check for leading or trailing slashes/dots
-    if (name[0] == '/' or name[name.len - 1] == '/' or
-        name[0] == '.' or name[name.len - 1] == '.')
-    {
-        return error.InvalidOSObjectName;
-    }
-
-    // Validate each character - allow limited-term chars plus dots
-    for (name) |c| {
-        const valid = isLimitedTermChar(c) or c == '.';
-        if (!valid) {
-            return error.InvalidOSObjectName;
-        }
     }
 }
 
@@ -418,21 +401,16 @@ test "validateOSBucketName" {
 }
 
 test "validateOSObjectName" {
-    // Valid object names
+    // Object names are unrestricted per ADR-20 (they are base64url-encoded
+    // to form the meta message subject)
     try validateOSObjectName("valid-object/name_123.txt");
     try validateOSObjectName("object_with-dashes");
     try validateOSObjectName("object/with/slashes");
     try validateOSObjectName("object=with=equals");
     try validateOSObjectName("object.with.dots");
+    try validateOSObjectName("object with space");
+    try validateOSObjectName("object*with>wildcards");
 
-    // Invalid object names
+    // Only the empty name is invalid
     try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName(""));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("/starts-with-slash"));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("ends-with-slash/"));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName(".starts-with-dot"));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("ends-with-dot."));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("object*with*asterisk"));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("object>with>gt"));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("object\\with\\backslash"));
-    try std.testing.expectError(error.InvalidOSObjectName, validateOSObjectName("object with space"));
 }

--- a/tests/jetstream_objstore_test.zig
+++ b/tests/jetstream_objstore_test.zig
@@ -176,8 +176,12 @@ test "ObjectStore delete operations" {
     try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.getBytes(object_name));
     try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.info(object_name));
 
-    // Deleting a deleted object reports not found as well.
-    try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.delete(object_name));
+    // Deleting again succeeds: delete is retryable so that a failed chunk
+    // purge can be finished on a retry.
+    try objstore.delete(object_name);
+
+    // Deleting an object that never existed is an error.
+    try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.delete("never-existed"));
 }
 
 test "ObjectStore list operations" {
@@ -402,4 +406,38 @@ test "ObjectStore wire format matches ADR-20" {
     }
 
     try objstore_manager.deleteStore(store_name);
+}
+
+test "ObjectStore put with zero chunk size uses the default" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    const js = conn.jetstream(.{});
+
+    const store_name = try utils.generateUniqueName(testing.allocator, "zerochunk");
+    defer testing.allocator.free(store_name);
+
+    var objstore_manager = js.objectStoreManager();
+    var objstore = try objstore_manager.createStore(.{ .store_name = store_name });
+    defer objstore.deinit();
+    defer objstore_manager.deleteStore(store_name) catch {};
+
+    // An explicit zero chunk size must fall back to the default instead of
+    // silently consuming no input and storing an empty object.
+    const content = "not an empty object";
+    var stream = nats.SliceReader{ .data = content };
+    const put_result = try objstore.put(.{
+        .name = "zero-chunk-object",
+        .opts = .{ .max_chunk_size = 0 },
+    }, &stream);
+    defer put_result.deinit();
+
+    try testing.expectEqual(@as(u64, content.len), put_result.value.size);
+    try testing.expectEqual(@as(u32, 1), put_result.value.chunks);
+
+    const get_result = try objstore.getBytes("zero-chunk-object");
+    defer get_result.deinit();
+    try testing.expectEqualStrings(content, get_result.value);
 }

--- a/tests/jetstream_objstore_test.zig
+++ b/tests/jetstream_objstore_test.zig
@@ -171,13 +171,13 @@ test "ObjectStore delete operations" {
     // Delete object
     try objstore.delete(object_name);
 
-    // Verify object is deleted
+    // Verify object is deleted; per ADR-20, deleted objects are treated
+    // as not found by both get and info.
     try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.getBytes(object_name));
+    try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.info(object_name));
 
-    // Info should show deleted status
-    const info_result = try objstore.info(object_name);
-    defer info_result.deinit();
-    try testing.expect(info_result.value.deleted);
+    // Deleting a deleted object reports not found as well.
+    try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.delete(object_name));
 }
 
 test "ObjectStore list operations" {
@@ -261,16 +261,13 @@ test "ObjectStore validation" {
     try testing.expectError(error.InvalidOSBucketName, nats.validateOSBucketName("invalid space"));
     try testing.expectError(error.InvalidOSBucketName, nats.validateOSBucketName("invalid.dot"));
 
-    // Test object name validation
+    // Object names are unrestricted per ADR-20; only empty is invalid.
     try testing.expectError(error.InvalidOSObjectName, nats.validateOSObjectName(""));
-    try testing.expectError(error.InvalidOSObjectName, nats.validateOSObjectName("/starts-with-slash"));
-    try testing.expectError(error.InvalidOSObjectName, nats.validateOSObjectName("ends-with-slash/"));
-    try testing.expectError(error.InvalidOSObjectName, nats.validateOSObjectName(".starts-with-dot"));
-    try testing.expectError(error.InvalidOSObjectName, nats.validateOSObjectName("ends-with-dot."));
 
     // Valid names should pass
     try nats.validateOSBucketName("valid-store_name123");
     try nats.validateOSObjectName("valid-object/name_123.txt");
+    try nats.validateOSObjectName("any name, even with spaces & symbols!");
 }
 
 test "ObjectStore error handling" {
@@ -302,4 +299,107 @@ test "ObjectStore error handling" {
 
     // Try to delete non-existent object
     try testing.expectError(nats.ObjectStoreError.ObjectNotFound, objstore.delete("nonexistent.txt"));
+}
+
+test "ObjectStore wire format matches ADR-20" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    const js = conn.jetstream(.{});
+
+    const store_name = try utils.generateUniqueName(testing.allocator, "wirestore");
+    defer testing.allocator.free(store_name);
+
+    var objstore_manager = js.objectStoreManager();
+    var objstore = try objstore_manager.createStore(.{
+        .store_name = store_name,
+        .chunk_size = 8,
+    });
+    defer objstore.deinit();
+
+    // A name that is not subject-safe, so it must be base64url-encoded.
+    const object_name = "dir/some file.txt";
+    const content = "hello object store wire format"; // 30 bytes -> 4 chunks of 8
+
+    var put_result = try objstore.putBytes(object_name, content);
+    defer put_result.deinit();
+
+    // The meta message must live on $O.<bucket>.M.<base64url(name)>,
+    // fetched here through the raw stream API, not the ObjectStore API.
+    var name_buf: [64]u8 = undefined;
+    const encoded_name = std.base64.url_safe.Encoder.encode(&name_buf, object_name);
+    const meta_subject = try std.fmt.allocPrint(testing.allocator, "$O.{s}.M.{s}", .{ store_name, encoded_name });
+    defer testing.allocator.free(meta_subject);
+    const stream_name = try std.fmt.allocPrint(testing.allocator, "OBJ_{s}", .{store_name});
+    defer testing.allocator.free(stream_name);
+
+    {
+        const meta_msg = try js.getMsg(stream_name, .{ .last_by_subj = meta_subject, .direct = true });
+        defer meta_msg.deinit();
+
+        // The raw JSON must follow the ADR-20 schema.
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, meta_msg.data, .{});
+        defer parsed.deinit();
+        const obj = parsed.value.object;
+
+        try testing.expect(obj.get("opts") == null); // pre-ADR schema must be gone
+        try testing.expectEqual(@as(i64, 4), obj.get("chunks").?.integer);
+        try testing.expectEqual(@as(i64, content.len), obj.get("size").?.integer);
+
+        const options = obj.get("options").?.object;
+        try testing.expectEqual(@as(i64, 8), options.get("max_chunk_size").?.integer);
+
+        // Digest: "SHA-256=" + padded base64url of the SHA-256 hash.
+        var hash: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(content, &hash, .{});
+        var digest_value_buf: [64]u8 = undefined;
+        const digest_value = std.base64.url_safe.Encoder.encode(&digest_value_buf, &hash);
+        const expected_digest = try std.fmt.allocPrint(testing.allocator, "SHA-256={s}", .{digest_value});
+        defer testing.allocator.free(expected_digest);
+        try testing.expectEqualStrings(expected_digest, obj.get("digest").?.string);
+    }
+
+    // 4 chunks + 1 meta message in the stream.
+    {
+        const si = try js.getStreamInfo(stream_name);
+        defer si.deinit();
+        try testing.expectEqual(@as(u64, 5), si.value.state.messages);
+    }
+
+    // Replace the object: the meta message rolls up and the previous
+    // object's chunks are purged, leaving 1 new chunk + 1 meta.
+    var put2_result = try objstore.putBytes(object_name, "xy");
+    defer put2_result.deinit();
+
+    {
+        const si = try js.getStreamInfo(stream_name);
+        defer si.deinit();
+        try testing.expectEqual(@as(u64, 2), si.value.state.messages);
+    }
+
+    // Delete: rolled-up tombstone with zeroed instance fields, chunks purged.
+    try objstore.delete(object_name);
+
+    {
+        const tomb_msg = try js.getMsg(stream_name, .{ .last_by_subj = meta_subject, .direct = true });
+        defer tomb_msg.deinit();
+
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, tomb_msg.data, .{});
+        defer parsed.deinit();
+        const obj = parsed.value.object;
+
+        try testing.expectEqual(true, obj.get("deleted").?.bool);
+        try testing.expectEqual(@as(i64, 0), obj.get("size").?.integer);
+        try testing.expectEqual(@as(i64, 0), obj.get("chunks").?.integer);
+    }
+
+    {
+        const si = try js.getStreamInfo(stream_name);
+        defer si.deinit();
+        try testing.expectEqual(@as(u64, 1), si.value.state.messages);
+    }
+
+    try objstore_manager.deleteStore(store_name);
 }


### PR DESCRIPTION
## Summary

Findings 11-13 from the static review. The Object Store round-tripped with itself but not with official clients. Every change below was verified against ADR-20 **and** the current nats.go `jetstream/object.go` (850f889, 2026-08-14):

- **Meta subjects**: `$O.<bucket>.M.<base64url(name)>` (padded URL-safe alphabet, matching Go's `base64.URLEncoding`). Object names are correspondingly unrestricted per the ADR — only empty is invalid — since the encoding makes them subject-safe.
- **Digest**: `SHA-256=<base64url>` instead of lowercase hex, verified by canonical string comparison like Go.
- **ObjectInfo JSON**: `options` / `max_chunk_size` keys (was `opts` / `chunk_size`); parsing ignores unknown fields (official clients write `mtime`, `headers`, `metadata`) and tolerates omitted ones (Go tombstones omit `digest`); null optionals are no longer emitted.
- **Rollup**: meta messages carry `Nats-Rollup: sub`, so one info message is retained per object instead of unbounded history.
- **Delete**: tombstone zeroes `size`/`chunks`/`digest` and the chunk subject is purged (previously the data was retained forever). Replacing an object purges the predecessor's chunks; a failed put purges its partial chunks. `info()` now treats deleted objects as not found, per the ADR.
- **`max_object_size` removed**: it mapped to per-message `max_msg_size`, which limits chunks, not objects (the field does not exist in official clients).

Also fixes a latent use-after-free found along the way: parsed ObjectInfo strings were slices into the already-released message payload (`alloc_if_needed` default); parsing now copies into the caller's arena (`alloc_always`).

Not addressed (missing features, not compat bugs): links, UpdateMeta, Watch, Seal, Status. A cross-client test against the `nats` CLI would be the definitive interop check and is left for a CI follow-up.

Note on finding 13's second claim: the ack `defer` inside the put loop runs at the end of each loop iteration (Zig scoping), so acks were never retained until return — no change needed there.

## Validation

- `./check.sh` passed (fmt, unit, full e2e; all 10 ObjectStore tests)
- new wire-format e2e test asserts subject encoding, JSON schema, digest, rollup, replace-purge, and delete-purge through the raw stream API, independent of the ObjectStore code paths