### PR TITLE
Bound the live write buffer and subscription pending messages

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -255,6 +255,11 @@ pub const ConnectionOptions = struct {
     ping_interval: Io.Duration = .fromSeconds(120), // .zero = disabled
     max_pings_out: u32 = 2, // max unanswered keep-alive PINGs
 
+    /// Maximum bytes buffered for writing on a live connection
+    /// (0 = unlimited). When full, publishers block (cancelable) until the
+    /// flusher catches up, like the buffered writers in nats.go and nats.c.
+    write_buffer_limit: usize = 8 * 1024 * 1024,
+
     // Authentication
     user: ?[]const u8 = null,
     password: ?[]const u8 = null,
@@ -360,7 +365,7 @@ pub const Connection = struct {
             .server_pool = ServerPool.init(allocator),
             .server_info_arena = std.heap.ArenaAllocator.init(allocator),
             .pending_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.reconnect.reconnect_buf_size }),
-            .write_buffer = WriteBuffer.init(allocator, io, .{}),
+            .write_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.write_buffer_limit, .block_when_full = true }),
             .subscriptions = std.AutoHashMap(u64, *Subscription).init(allocator),
             .response_manager = ResponseManager.init(allocator, io),
             .parser = Parser.init(allocator, io),
@@ -1317,6 +1322,18 @@ pub const Connection = struct {
         try gather.consume(bytes_written);
     }
 
+    /// Count a dropped message and report the start of a slow-consumer
+    /// episode through the error callback (once per episode, like nats.go).
+    fn handleSlowConsumer(self: *Self, sub: *Subscription) void {
+        _ = sub.dropped_msgs.fetchAdd(1, .monotonic);
+        if (sub.slow_consumer.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
+            log.warn("Slow consumer, messages dropped for subscription {d} ({s})", .{ sub.sid, sub.subject });
+            if (self.options.callbacks.error_cb) |cb| {
+                cb(self, "Slow Consumer, messages dropped");
+            }
+        }
+    }
+
     // Parser callback methods
     pub fn processMsg(self: *Self, message: *Message) !void {
         var owns_message = true;
@@ -1339,6 +1356,18 @@ pub const Connection = struct {
                 return;
             }
 
+            // Slow-consumer protection: drop the message when a pending
+            // limit is exceeded. Limits are measured on message counts and
+            // payload bytes, never on queue storage.
+            const msgs_limit = s.pending_msgs_limit.load(.acquire);
+            const bytes_limit = s.pending_bytes_limit.load(.acquire);
+            if ((msgs_limit > 0 and s.pending_msgs.load(.acquire) >= msgs_limit) or
+                (bytes_limit > 0 and s.pending_bytes.load(.acquire) + message.data.len > bytes_limit))
+            {
+                self.handleSlowConsumer(s);
+                return;
+            }
+
             // Increment pending message count and bytes for this subscription
             subscription_mod.incrementPending(s, message.data.len);
 
@@ -1358,15 +1387,19 @@ pub const Connection = struct {
                     },
                     error.Canceled => return error.Canceled,
                     else => {
-                        // Allocation or unexpected push failure; log and tear down the connection.
+                        // Allocation failure: drop this one message instead
+                        // of tearing down the connection for all
+                        // subscriptions.
                         log.err("Failed to enqueue message for sid {d}: {}", .{ message.sid, err });
-                        // Undo the pending counters since we failed to enqueue
                         subscription_mod.decrementPending(s, message.data.len);
-                        return err;
+                        self.handleSlowConsumer(s);
+                        return;
                     },
                 }
             };
             owns_message = false;
+            // A successful delivery ends a slow-consumer episode.
+            s.slow_consumer.store(false, .release);
         } else {
             // No sub subscription found, try to send UNSUB command
             self.unsubscribeInternal(message.sid, null) catch |err| {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1366,6 +1366,9 @@ pub const Connection = struct {
     /// with no locks held and the subscription retained.
     fn handleSlowConsumer(self: *Self, sub: *Subscription) void {
         const total_dropped = sub.dropped_msgs.fetchAdd(1, .monotonic) + 1;
+        // Arm the in-band error for synchronous receivers (re-armed by
+        // every drop, so a gap after a consumed error is still reported).
+        sub.sc_error_pending.store(true, .release);
         if (sub.slow_consumer.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
             log.warn("Slow consumer, messages dropped for subscription {d} ({s})", .{ sub.sid, sub.subject });
             if (self.options.callbacks.slow_consumer_cb) |cb| {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -751,7 +751,7 @@ pub const Connection = struct {
         } else {
             try buffer.writer.print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
         }
-        try self.write_buffer.appendControl(buffer.written());
+        try self.write_buffer.appendUnmetered(buffer.written());
     }
 
     pub fn subscribe(self: *Self, subject: []const u8, comptime handlerFn: anytype, args: anytype) !*Subscription {
@@ -838,7 +838,7 @@ pub const Connection = struct {
         if (self.status == .reconnecting and self.options.reconnect.allow_reconnect) {
             try self.pending_buffer.append(writer.buffered());
         } else {
-            try self.write_buffer.appendControl(writer.buffered());
+            try self.write_buffer.appendUnmetered(writer.buffered());
         }
     }
 
@@ -1573,7 +1573,7 @@ pub const Connection = struct {
         try buffer.writer.writeAll("PING\r\n");
 
         // Send via buffer (mutex already held)
-        try self.write_buffer.appendControl(buffer.written());
+        try self.write_buffer.appendUnmetered(buffer.written());
 
         log.debug("Sent CONNECT+PING during handshake", .{});
     }
@@ -1743,7 +1743,7 @@ pub const Connection = struct {
     }
 
     fn sendPing(self: *Self, comptime lock: bool) !u64 {
-        try self.write_buffer.appendControl("PING\r\n");
+        try self.write_buffer.appendUnmetered("PING\r\n");
 
         if (lock) try self.mutex.lock(self.io);
         defer if (lock) self.mutex.unlock(self.io);
@@ -1805,7 +1805,7 @@ pub const Connection = struct {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
 
-        try self.write_buffer.appendControl("PONG\r\n");
+        try self.write_buffer.appendUnmetered("PONG\r\n");
     }
 
     fn calculateReconnectDelay(self: *Self, attempts: u32) Io.Duration {
@@ -1883,7 +1883,7 @@ pub const Connection = struct {
 
             // Send all subscription commands via write buffer
             if (buffer.written().len > 0) {
-                try self.write_buffer.appendControl(buffer.written());
+                try self.write_buffer.appendUnmetered(buffer.written());
             }
         }
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -212,6 +212,11 @@ pub const ConnectionCallbacks = struct {
     reconnected_cb: ?*const fn (*Connection) void = null,
     closed_cb: ?*const fn (*Connection) void = null,
     error_cb: ?*const fn (*Connection, []const u8) void = null,
+    /// Called once per slow-consumer episode with the subscription that
+    /// dropped a message and its cumulative dropped count. Invoked outside
+    /// connection and queue locks; the subscription is retained for the
+    /// duration of the call.
+    slow_consumer_cb: ?*const fn (*Connection, *Subscription, u64) void = null,
 };
 
 const ExitReason = enum(u8) {
@@ -255,9 +260,12 @@ pub const ConnectionOptions = struct {
     ping_interval: Io.Duration = .fromSeconds(120), // .zero = disabled
     max_pings_out: u32 = 2, // max unanswered keep-alive PINGs
 
-    /// Maximum bytes buffered for writing on a live connection
-    /// (0 = unlimited). When full, publishers block (cancelable) until the
-    /// flusher catches up, like the buffered writers in nats.go and nats.c.
+    /// High-water mark for bytes buffered on a live connection
+    /// (0 = unlimited). When exceeded, publishers wait (cancelably,
+    /// without holding connection locks) for the flusher to catch up,
+    /// like the buffered writers in nats.go and nats.c. A single message
+    /// larger than the limit is still accepted into an empty buffer, and
+    /// small control frames (PING, SUB, ...) always go through.
     write_buffer_limit: usize = 8 * 1024 * 1024,
 
     // Authentication
@@ -365,7 +373,7 @@ pub const Connection = struct {
             .server_pool = ServerPool.init(allocator),
             .server_info_arena = std.heap.ArenaAllocator.init(allocator),
             .pending_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.reconnect.reconnect_buf_size }),
-            .write_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.write_buffer_limit, .block_when_full = true }),
+            .write_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.write_buffer_limit, .soft_limit = true }),
             .subscriptions = std.AutoHashMap(u64, *Subscription).init(allocator),
             .response_manager = ResponseManager.init(allocator, io),
             .parser = Parser.init(allocator, io),
@@ -620,6 +628,27 @@ pub const Connection = struct {
     }
 
     fn publishMsgInternal(self: *Self, msg: *Message, reply_override: ?[]const u8) !void {
+        while (true) {
+            return self.publishMsgAttempt(msg, reply_override) catch |err| switch (err) {
+                error.NoSpace => {
+                    // The live write buffer is over its high-water mark.
+                    // Wait for the flusher outside of Connection.mutex, so
+                    // reconnect and close can always proceed (both wake the
+                    // waiters), then retry with the connection state
+                    // re-checked (it may route to the pending buffer now).
+                    const estimated_size = msg.data.len + 512;
+                    self.write_buffer.queue.waitForSpace(estimated_size) catch |wait_err| switch (wait_err) {
+                        error.Closed => return ConnectionError.ConnectionClosed,
+                        error.Canceled => |e| return e,
+                    };
+                    continue;
+                },
+                else => |other| return other,
+            };
+        }
+    }
+
+    fn publishMsgAttempt(self: *Self, msg: *Message, reply_override: ?[]const u8) !void {
         if (self.drain_state.load(.acquire) == .draining_pubs) {
             return error.DrainInProgress;
         }
@@ -1323,13 +1352,14 @@ pub const Connection = struct {
     }
 
     /// Count a dropped message and report the start of a slow-consumer
-    /// episode through the error callback (once per episode, like nats.go).
+    /// episode (once per episode, like nats.go). Called from processMsg
+    /// with no locks held and the subscription retained.
     fn handleSlowConsumer(self: *Self, sub: *Subscription) void {
-        _ = sub.dropped_msgs.fetchAdd(1, .monotonic);
+        const total_dropped = sub.dropped_msgs.fetchAdd(1, .monotonic) + 1;
         if (sub.slow_consumer.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
             log.warn("Slow consumer, messages dropped for subscription {d} ({s})", .{ sub.sid, sub.subject });
-            if (self.options.callbacks.error_cb) |cb| {
-                cb(self, "Slow Consumer, messages dropped");
+            if (self.options.callbacks.slow_consumer_cb) |cb| {
+                cb(self, sub, total_dropped);
             }
         }
     }
@@ -1387,13 +1417,11 @@ pub const Connection = struct {
                     },
                     error.Canceled => return error.Canceled,
                     else => {
-                        // Allocation failure: drop this one message instead
-                        // of tearing down the connection for all
-                        // subscriptions.
+                        // Real allocation failure: this remains a connection
+                        // error (unlike a configured pending-limit drop).
                         log.err("Failed to enqueue message for sid {d}: {}", .{ message.sid, err });
                         subscription_mod.decrementPending(s, message.data.len);
-                        self.handleSlowConsumer(s);
-                        return;
+                        return err;
                     },
                 }
             };

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -628,16 +628,18 @@ pub const Connection = struct {
     }
 
     fn publishMsgInternal(self: *Self, msg: *Message, reply_override: ?[]const u8) !void {
+        var frame_size: usize = 0;
         while (true) {
-            return self.publishMsgAttempt(msg, reply_override) catch |err| switch (err) {
+            return self.publishMsgAttempt(msg, reply_override, &frame_size) catch |err| switch (err) {
                 error.NoSpace => {
                     // The live write buffer is over its high-water mark.
                     // Wait for the flusher outside of Connection.mutex, so
                     // reconnect and close can always proceed (both wake the
                     // waiters), then retry with the connection state
                     // re-checked (it may route to the pending buffer now).
-                    const estimated_size = msg.data.len + 512;
-                    self.write_buffer.queue.waitForSpace(estimated_size) catch |wait_err| switch (wait_err) {
+                    // The failed attempt reported the exact frame size, so
+                    // the wait cannot return before the frame actually fits.
+                    self.write_buffer.queue.waitForSpace(frame_size) catch |wait_err| switch (wait_err) {
                         error.Closed => return ConnectionError.ConnectionClosed,
                         error.Canceled => |e| return e,
                     };
@@ -648,7 +650,7 @@ pub const Connection = struct {
         }
     }
 
-    fn publishMsgAttempt(self: *Self, msg: *Message, reply_override: ?[]const u8) !void {
+    fn publishMsgAttempt(self: *Self, msg: *Message, reply_override: ?[]const u8, frame_size: *usize) !void {
         if (self.drain_state.load(.acquire) == .draining_pubs) {
             return error.DrainInProgress;
         }
@@ -708,6 +710,7 @@ pub const Connection = struct {
 
         // Append control+headers, data, and trailer without copying msg.data
         const slices = &[_][]const u8{ buffer_writer.buffered(), msg.data, "\r\n" };
+        frame_size.* = buffer_writer.buffered().len + msg.data.len + 2;
 
         // Published messages go to pending_buffer during reconnection, otherwise write_buffer
         if (self.status == .reconnecting and self.options.reconnect.allow_reconnect) {
@@ -748,7 +751,7 @@ pub const Connection = struct {
         } else {
             try buffer.writer.print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
         }
-        try self.write_buffer.append(buffer.written());
+        try self.write_buffer.appendControl(buffer.written());
     }
 
     pub fn subscribe(self: *Self, subject: []const u8, comptime handlerFn: anytype, args: anytype) !*Subscription {
@@ -835,7 +838,7 @@ pub const Connection = struct {
         if (self.status == .reconnecting and self.options.reconnect.allow_reconnect) {
             try self.pending_buffer.append(writer.buffered());
         } else {
-            try self.write_buffer.append(writer.buffered());
+            try self.write_buffer.appendControl(writer.buffered());
         }
     }
 
@@ -1062,6 +1065,13 @@ pub const Connection = struct {
 
                 self.status = .reconnecting;
                 self.status_cond.broadcast(self.io);
+
+                // Discard whatever was buffered for the dead socket. This
+                // also wakes publishers blocked in waitForSpace, so they
+                // re-check the status and reroute into pending_buffer
+                // instead of waiting out the whole reconnect. The reader
+                // and flusher tasks are already joined at this point.
+                self.write_buffer.reset();
 
                 if (self.options.callbacks.disconnected_cb) |cb| {
                     callback = cb;
@@ -1563,7 +1573,7 @@ pub const Connection = struct {
         try buffer.writer.writeAll("PING\r\n");
 
         // Send via buffer (mutex already held)
-        try self.write_buffer.append(buffer.written());
+        try self.write_buffer.appendControl(buffer.written());
 
         log.debug("Sent CONNECT+PING during handshake", .{});
     }
@@ -1733,7 +1743,7 @@ pub const Connection = struct {
     }
 
     fn sendPing(self: *Self, comptime lock: bool) !u64 {
-        try self.write_buffer.append("PING\r\n");
+        try self.write_buffer.appendControl("PING\r\n");
 
         if (lock) try self.mutex.lock(self.io);
         defer if (lock) self.mutex.unlock(self.io);
@@ -1795,7 +1805,7 @@ pub const Connection = struct {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
 
-        try self.write_buffer.append("PONG\r\n");
+        try self.write_buffer.appendControl("PONG\r\n");
     }
 
     fn calculateReconnectDelay(self: *Self, attempts: u32) Io.Duration {
@@ -1873,7 +1883,7 @@ pub const Connection = struct {
 
             // Send all subscription commands via write buffer
             if (buffer.written().len > 0) {
-                try self.write_buffer.append(buffer.written());
+                try self.write_buffer.appendControl(buffer.written());
             }
         }
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1366,10 +1366,14 @@ pub const Connection = struct {
     /// with no locks held and the subscription retained.
     fn handleSlowConsumer(self: *Self, sub: *Subscription) void {
         const total_dropped = sub.dropped_msgs.fetchAdd(1, .monotonic) + 1;
-        // Arm the in-band error for synchronous receivers (re-armed by
-        // every drop, so a gap after a consumed error is still reported).
-        sub.sc_error_pending.store(true, .release);
         if (sub.slow_consumer.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
+            // Arm the in-band error once when a synchronous subscription
+            // enters a slow-consumer episode. Further drops in the same
+            // episode must not prevent the receiver from draining queued
+            // messages; a successful enqueue ends the episode below.
+            if (sub.handler == null) {
+                sub.sc_error_pending.store(true, .release);
+            }
             log.warn("Slow consumer, messages dropped for subscription {d} ({s})", .{ sub.sid, sub.subject });
             if (self.options.callbacks.slow_consumer_cb) |cb| {
                 cb(self, sub, total_dropped);

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -523,8 +523,11 @@ pub const PullSubscription = struct {
                     // Timeout occurred
                     batch_complete = true;
                 },
-                error.Canceled, error.ConnectionClosed => {
-                    // Propagate cancellation and closed connections
+                error.Canceled, error.ConnectionClosed, error.SlowConsumer => {
+                    // Propagate cancellation and closed connections.
+                    // SlowConsumer cannot occur here (the inbox limits are
+                    // sized to the consumer's ack window), but if it ever
+                    // does, surfacing it beats silently losing a gap.
                     return err;
                 },
             }

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -1278,6 +1278,27 @@ pub const JetStream = struct {
     }
 
     /// Subscribe to a JetStream push consumer with callback handler
+    /// Size a JetStream delivery subscription's pending limits so that
+    /// slow-consumer protection can never drop a JetStream message
+    /// (nats.go behavior): with acks, the server sends at most
+    /// max_ack_pending unacked messages, so the queue is guaranteed to
+    /// hold the full in-flight window. Consumers without acks (or with an
+    /// unlimited ack window) have no server-side in-flight bound and no
+    /// redelivery to recover a drop, so their limits are lifted entirely.
+    fn applyPendingLimits(subscription: *Subscription, consumer_config: *const ConsumerConfig) void {
+        if (consumer_config.ack_policy == .none or consumer_config.max_ack_pending <= 0) {
+            subscription.setPendingLimits(0, 0);
+            return;
+        }
+
+        const max_ack_pending: u64 = @intCast(consumer_config.max_ack_pending);
+        if (max_ack_pending > Subscription.default_pending_msgs_limit) {
+            const msgs_limit: u32 = std.math.cast(u32, max_ack_pending) orelse std.math.maxInt(u32);
+            const bytes_limit = @max(max_ack_pending * 1024 * 1024, Subscription.default_pending_bytes_limit);
+            subscription.setPendingLimits(msgs_limit, bytes_limit);
+        }
+    }
+
     pub fn subscribe(self: JetStream, subject: ?[]const u8, comptime handlerFn: anytype, handler_args: anytype, options: SubscribeOptions) !*JetStreamSubscription {
         // Resolve stream name
         const stream_name = if (options.stream) |s|
@@ -1318,6 +1339,8 @@ pub const JetStream = struct {
         // Subscribe to the delivery subject
         const subscription = try self.nc.subscribe(deliver_subject, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
         errdefer self.nc.unsubscribe(subscription);
+
+        applyPendingLimits(subscription, &consumer_info.value.config);
 
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
@@ -1371,6 +1394,8 @@ pub const JetStream = struct {
         // Create synchronous subscription (no callback handler)
         const subscription = try self.nc.subscribeSync(deliver_subject);
         errdefer self.nc.unsubscribe(subscription);
+
+        applyPendingLimits(subscription, &consumer_info.value.config);
 
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
@@ -1427,6 +1452,8 @@ pub const JetStream = struct {
         const subscription = try self.nc.queueSubscribe(deliver_subject, queue, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
         errdefer self.nc.unsubscribe(subscription);
 
+        applyPendingLimits(subscription, &consumer_info.value.config);
+
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
         js_sub.* = JetStreamSubscription{
@@ -1480,6 +1507,8 @@ pub const JetStream = struct {
         const subscription = try self.nc.queueSubscribeSync(deliver_subject, queue);
         errdefer self.nc.unsubscribe(subscription);
 
+        applyPendingLimits(subscription, &consumer_info.value.config);
+
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
         js_sub.* = JetStreamSubscription{
@@ -1527,6 +1556,8 @@ pub const JetStream = struct {
         // Create the persistent wildcard inbox subscription
         const inbox_subscription = try self.nc.subscribeSync(wildcard_subject);
         errdefer self.nc.unsubscribe(inbox_subscription);
+
+        applyPendingLimits(inbox_subscription, &consumer_info.value.config);
 
         // Allocate PullSubscription
         const pull_subscription = try self.nc.allocator.create(PullSubscription);

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -1280,28 +1280,21 @@ pub const JetStream = struct {
         };
     }
 
-    /// Subscribe to a JetStream push consumer with callback handler
-    /// Size a JetStream delivery subscription's pending limits so that
-    /// slow-consumer protection can never drop a JetStream message
-    /// (nats.go behavior): with acks, the server sends at most
-    /// max_ack_pending unacked messages, so the queue is guaranteed to
-    /// hold the full in-flight window. Consumers without acks (or with an
-    /// unlimited ack window) have no server-side in-flight bound and no
-    /// redelivery to recover a drop, so their limits are lifted entirely.
+    /// Keep JetStream delivery subscriptions bounded, while matching
+    /// nats.go's adjustment when the server's max-ack-pending window exceeds
+    /// the default message limit. MaxAckPending is not a no-drop guarantee:
+    /// byte limits, redeliveries, and control messages are independent of the
+    /// number of unique unacknowledged messages.
     fn applyPendingLimits(subscription: *Subscription, consumer_config: *const ConsumerConfig) void {
-        if (consumer_config.ack_policy == .none or consumer_config.max_ack_pending <= 0) {
-            subscription.setPendingLimits(0, 0);
-            return;
-        }
+        if (consumer_config.max_ack_pending <= Subscription.default_pending_msgs_limit) return;
 
         const max_ack_pending: u64 = @intCast(consumer_config.max_ack_pending);
-        if (max_ack_pending > Subscription.default_pending_msgs_limit) {
-            const msgs_limit: u32 = std.math.cast(u32, max_ack_pending) orelse std.math.maxInt(u32);
-            const bytes_limit = @max(max_ack_pending * 1024 * 1024, Subscription.default_pending_bytes_limit);
-            subscription.setPendingLimits(msgs_limit, bytes_limit);
-        }
+        const msgs_limit: u32 = std.math.cast(u32, max_ack_pending) orelse std.math.maxInt(u32);
+        const bytes_limit = @max(max_ack_pending *| @as(u64, 1024 * 1024), Subscription.default_pending_bytes_limit);
+        subscription.setPendingLimits(msgs_limit, bytes_limit);
     }
 
+    /// Subscribe to a JetStream push consumer with callback handler.
     pub fn subscribe(self: JetStream, subject: ?[]const u8, comptime handlerFn: anytype, handler_args: anytype, options: SubscribeOptions) !*JetStreamSubscription {
         // Resolve stream name
         const stream_name = if (options.stream) |s|

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -173,6 +173,8 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         mutex: xsync.Mutex,
         /// Condition variable for waiting readers
         data_cond: xsync.Condition,
+        /// Condition variable for writers waiting for space (block_when_full)
+        space_cond: xsync.Condition,
 
         /// Head of the linked list (oldest chunk, protected by mutex)
         head: ?*Chunk,
@@ -187,6 +189,9 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         max_chunks: usize,
         /// Maximum total bytes allowed (0 = unlimited)
         max_size: usize,
+        /// Whether writers block waiting for space instead of erroring
+        /// when max_size is reached
+        block_when_full: bool,
 
         /// Pool of reusable chunks (protected by mutex)
         chunk_pool: Pool,
@@ -208,6 +213,9 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             max_chunks: usize = 0,
             /// Maximum total bytes allowed (0 = unlimited)
             max_size: usize = 0,
+            /// When max_size is reached, block writers (cancelable) until
+            /// readers consume data, instead of failing the push
+            block_when_full: bool = false,
         };
 
         pub fn init(allocator: Allocator, io: Io, config: Config) Self {
@@ -216,12 +224,14 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 .io = io,
                 .mutex = .init,
                 .data_cond = .init,
+                .space_cond = .init,
                 .head = null,
                 .tail = null,
                 .items_available = 0,
                 .total_chunks = 0,
                 .max_chunks = config.max_chunks,
                 .max_size = config.max_size,
+                .block_when_full = config.block_when_full,
                 .chunk_pool = Pool.init(allocator, config.max_pool_size),
                 .is_closed = false,
                 .reset_id = 0,
@@ -242,6 +252,33 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         }
 
         /// Push a single item (fiber-safe, cancelable)
+        /// Enforce the size limit for `needed` additional items; blocks
+        /// waiting for readers when configured to do so. Assumes the mutex
+        /// is held; may release it while waiting.
+        fn reserveSpaceLocked(self: *Self, needed: usize) (Io.Cancelable || PushError)!void {
+            if (self.max_size == 0) return;
+
+            const max_items = self.max_size / @sizeOf(T);
+            if (needed > max_items) {
+                // Can never fit, waiting would deadlock
+                return PushError.OutOfMemory;
+            }
+
+            if (!self.block_when_full) {
+                if (self.items_available + needed > max_items) {
+                    return PushError.OutOfMemory;
+                }
+                return;
+            }
+
+            while (!self.is_closed and self.items_available + needed > max_items) {
+                try self.space_cond.wait(self.io, &self.mutex);
+            }
+            if (self.is_closed) {
+                return PushError.Closed;
+            }
+        }
+
         pub fn push(self: *Self, item: T) (Io.Cancelable || PushError)!void {
             try self.mutex.lock(self.io);
             defer self.mutex.unlock(self.io);
@@ -250,13 +287,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return PushError.Closed;
             }
 
-            // Check size limit before adding (overflow-safe)
-            if (self.max_size > 0) {
-                const max_items = self.max_size / @sizeOf(T);
-                if (self.items_available >= max_items) {
-                    return PushError.OutOfMemory;
-                }
-            }
+            try self.reserveSpaceLocked(1);
 
             const chunk = try self.ensureWritableChunk();
             const success = chunk.pushItem(item);
@@ -279,16 +310,8 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return PushError.Closed;
             }
 
-            // Check size limit before adding (overflow-safe)
-            if (self.max_size > 0) {
-                const max_items = self.max_size / @sizeOf(T);
-                if (self.items_available >= max_items) {
-                    return PushError.OutOfMemory;
-                }
-                if (items.len > max_items - self.items_available) {
-                    return PushError.OutOfMemory;
-                }
-            }
+            try self.reserveSpaceLocked(items.len);
+
             var remaining = items;
             var total_written: usize = 0;
 
@@ -361,12 +384,20 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             return self.popLocked() orelse unreachable;
         }
 
+        /// Wake writers waiting for space. Assumes the mutex is held.
+        fn notifySpaceLocked(self: *Self) void {
+            if (self.block_when_full and self.max_size > 0) {
+                self.space_cond.broadcast(self.io);
+            }
+        }
+
         /// Pop the next available item; assumes the mutex is held.
         fn popLocked(self: *Self) ?T {
             const chunk = self.head orelse return null;
             const item = chunk.popItem() orelse return null;
 
             self.items_available -= 1;
+            self.notifySpaceLocked();
 
             // Check if chunk is fully consumed
             if (chunk.isFullyConsumed()) {
@@ -433,6 +464,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
             chunk.read_pos += items_consumed;
             self.items_available -= items_consumed;
+            self.notifySpaceLocked();
 
             // Check if we can advance head and recycle chunks
             while (self.head) |head_chunk| {
@@ -471,6 +503,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
             self.is_closed = true;
             self.data_cond.broadcast(self.io);
+            self.notifySpaceLocked();
         }
 
         /// Check if the queue is closed
@@ -503,6 +536,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
             // Wake up any waiting fibers
             self.data_cond.broadcast(self.io);
+            self.notifySpaceLocked();
         }
 
         // Private helper functions
@@ -632,16 +666,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
                 total_size += slice.len;
             }
 
-            // Check size limit before adding (overflow-safe)
-            if (self.queue.max_size > 0) {
-                const max_items = self.queue.max_size;
-                if (self.queue.items_available >= max_items) {
-                    return PushError.OutOfMemory;
-                }
-                if (total_size > max_items - self.queue.items_available) {
-                    return PushError.OutOfMemory;
-                }
-            }
+            try self.queue.reserveSpaceLocked(total_size);
 
             // Append each slice
             for (slices) |slice| {
@@ -754,6 +779,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
             var remaining = total_bytes;
 
             self.queue.items_available -= total_bytes;
+            self.queue.notifySpaceLocked();
 
             while (self.queue.head) |head_chunk| {
                 if (remaining == 0) break;
@@ -846,6 +872,7 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
             self.queue.head = null;
             self.queue.tail = null;
             self.queue.items_available = 0;
+            self.queue.notifySpaceLocked();
             // Sanity: we only subtract list-chunks; pooled chunks remain accounted.
             std.debug.assert(self.queue.total_chunks >= moved_chunk_count);
             self.queue.total_chunks -= moved_chunk_count;
@@ -1445,4 +1472,75 @@ test "VectorGather detects concurrent consumer advancing buffer" {
 
     // Now trying to consume with the original gather should fail with ConcurrentConsumer
     try std.testing.expectError(error.ConcurrentConsumer, gather.consume(3));
+}
+
+test "blocking append waits for space" {
+    const allocator = std.testing.allocator;
+
+    const Buffer = ConcurrentWriteBuffer(16);
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .block_when_full = true });
+    defer buffer.deinit();
+
+    try buffer.append("12345678"); // exactly full
+
+    const Helper = struct {
+        fn consumer(io: std.Io, buf: *Buffer) void {
+            // Give the appender time to block, then free space.
+            io.sleep(.fromMilliseconds(20), .awake) catch return;
+            var view = buf.getSlice(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } }) catch return;
+            view.consume(4);
+        }
+    };
+
+    var consumer_task = try std.testing.io.concurrent(Helper.consumer, .{ std.testing.io, &buffer });
+    defer consumer_task.cancel(std.testing.io);
+
+    // Blocks until the consumer frees 4 bytes.
+    try buffer.append("abcd");
+
+    try std.testing.expectEqual(@as(usize, 8), buffer.queue.getItemsAvailable());
+}
+
+test "blocking append larger than capacity fails" {
+    const allocator = std.testing.allocator;
+
+    const Buffer = ConcurrentWriteBuffer(16);
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .block_when_full = true });
+    defer buffer.deinit();
+
+    // Could never fit, must fail instead of blocking forever.
+    try std.testing.expectError(PushError.OutOfMemory, buffer.append("123456789"));
+}
+
+test "close wakes a blocked appender" {
+    const allocator = std.testing.allocator;
+
+    const Buffer = ConcurrentWriteBuffer(16);
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .block_when_full = true });
+    defer buffer.deinit();
+
+    try buffer.append("12345678"); // full
+
+    const Helper = struct {
+        fn closer(io: std.Io, buf: *Buffer) void {
+            io.sleep(.fromMilliseconds(20), .awake) catch return;
+            buf.close();
+        }
+    };
+
+    var closer_task = try std.testing.io.concurrent(Helper.closer, .{ std.testing.io, &buffer });
+    defer closer_task.cancel(std.testing.io);
+
+    try std.testing.expectError(PushError.Closed, buffer.append("more"));
+}
+
+test "non-blocking append still fails when full" {
+    const allocator = std.testing.allocator;
+
+    const Buffer = ConcurrentWriteBuffer(16);
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8 });
+    defer buffer.deinit();
+
+    try buffer.append("12345678");
+    try std.testing.expectError(PushError.OutOfMemory, buffer.append("x"));
 }

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -744,10 +744,11 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
             return self.queue.tryGetSlice();
         }
 
-        /// Append protocol control data, bypassing any soft limit: control
-        /// frames and connection-restoration data must never be refused
-        /// once the connection state says they should be sent.
-        pub fn appendControl(self: *Self, data: []const u8) (Io.Cancelable || PushError)!void {
+        /// Append bypassing any soft limit. For data that must never be
+        /// refused once the caller has decided it should be sent (the
+        /// connection uses this for protocol control frames and
+        /// subscription restoration).
+        pub fn appendUnmetered(self: *Self, data: []const u8) (Io.Cancelable || PushError)!void {
             return self.queue.pushSliceUnmetered(data);
         }
 
@@ -1528,8 +1529,8 @@ test "soft limit meters bulk appends with NoSpace" {
     // ...and metered single appends as well...
     try std.testing.expectError(PushError.NoSpace, buffer.append("PING"));
 
-    // ...but control appends always go through (overshoot allowed).
-    try buffer.appendControl("PING");
+    // ...but unmetered appends always go through (overshoot allowed).
+    try buffer.appendUnmetered("PING");
     try std.testing.expectEqual(@as(usize, 12), buffer.queue.getItemsAvailable());
 
     // Drain completely; a lone bulk append larger than the whole limit is

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -309,11 +309,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return PushError.Closed;
             }
 
-            // Soft-limited queues only meter bulk appends (appendMany);
-            // single items and slices are small control data.
-            if (!self.soft_limit) {
-                try self.reserveSpaceLocked(1);
-            }
+            try self.reserveSpaceLocked(1);
 
             const chunk = try self.ensureWritableChunk();
             const success = chunk.pushItem(item);
@@ -329,6 +325,18 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
         /// Push multiple items (fiber-safe, cancelable)
         pub fn pushSlice(self: *Self, items: []const T) (Io.Cancelable || PushError)!void {
+            return self.pushSliceInner(items, true);
+        }
+
+        /// Push multiple items bypassing any size limit. For protocol
+        /// control data that must never be refused once the caller has
+        /// decided it should be sent (PING/PONG/CONNECT/(UN)SUB and
+        /// subscription restoration).
+        pub fn pushSliceUnmetered(self: *Self, items: []const T) (Io.Cancelable || PushError)!void {
+            return self.pushSliceInner(items, false);
+        }
+
+        fn pushSliceInner(self: *Self, items: []const T, metered: bool) (Io.Cancelable || PushError)!void {
             try self.mutex.lock(self.io);
             defer self.mutex.unlock(self.io);
 
@@ -336,8 +344,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return PushError.Closed;
             }
 
-            // See push: control-sized appends bypass a soft limit.
-            if (!self.soft_limit) {
+            if (metered) {
                 try self.reserveSpaceLocked(items.len);
             }
 
@@ -735,6 +742,13 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
         /// Get readable byte slice
         pub fn tryGetSlice(self: *Self) ?Queue.View {
             return self.queue.tryGetSlice();
+        }
+
+        /// Append protocol control data, bypassing any soft limit: control
+        /// frames and connection-restoration data must never be refused
+        /// once the connection state says they should be sent.
+        pub fn appendControl(self: *Self, data: []const u8) (Io.Cancelable || PushError)!void {
+            return self.queue.pushSliceUnmetered(data);
         }
 
         /// Get readable byte slice with timeout
@@ -1511,8 +1525,11 @@ test "soft limit meters bulk appends with NoSpace" {
     // Over the high-water mark: bulk appends are rejected with NoSpace...
     try std.testing.expectError(PushError.NoSpace, buffer.appendMany(&.{"x"}));
 
-    // ...but control-sized appends always go through (overshoot allowed).
-    try buffer.append("PING");
+    // ...and metered single appends as well...
+    try std.testing.expectError(PushError.NoSpace, buffer.append("PING"));
+
+    // ...but control appends always go through (overshoot allowed).
+    try buffer.appendControl("PING");
     try std.testing.expectEqual(@as(usize, 12), buffer.queue.getItemsAvailable());
 
     // Drain completely; a lone bulk append larger than the whole limit is

--- a/src/queue.zig
+++ b/src/queue.zig
@@ -26,6 +26,9 @@ pub const PushError = error{
     Closed,
     ChunkLimitExceeded,
     OutOfMemory,
+    /// A soft-limited queue is over its high-water mark; the caller can
+    /// wait for space (see `waitForSpace`) and retry.
+    NoSpace,
 };
 
 /// A single chunk in the linked list with inline data
@@ -173,7 +176,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         mutex: xsync.Mutex,
         /// Condition variable for waiting readers
         data_cond: xsync.Condition,
-        /// Condition variable for writers waiting for space (block_when_full)
+        /// Condition variable for writers waiting for space (soft_limit mode)
         space_cond: xsync.Condition,
 
         /// Head of the linked list (oldest chunk, protected by mutex)
@@ -189,9 +192,11 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
         max_chunks: usize,
         /// Maximum total bytes allowed (0 = unlimited)
         max_size: usize,
-        /// Whether writers block waiting for space instead of erroring
-        /// when max_size is reached
-        block_when_full: bool,
+        /// Whether max_size is a high-water mark (soft limit) rather than a
+        /// hard cap: an append into an empty queue may overshoot the limit,
+        /// and an over-limit append fails with NoSpace so the caller can
+        /// wait for space and retry
+        soft_limit: bool,
 
         /// Pool of reusable chunks (protected by mutex)
         chunk_pool: Pool,
@@ -213,9 +218,9 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             max_chunks: usize = 0,
             /// Maximum total bytes allowed (0 = unlimited)
             max_size: usize = 0,
-            /// When max_size is reached, block writers (cancelable) until
-            /// readers consume data, instead of failing the push
-            block_when_full: bool = false,
+            /// Treat max_size as a high-water mark instead of a hard cap
+            /// (see the field documentation)
+            soft_limit: bool = false,
         };
 
         pub fn init(allocator: Allocator, io: Io, config: Config) Self {
@@ -231,7 +236,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 .total_chunks = 0,
                 .max_chunks = config.max_chunks,
                 .max_size = config.max_size,
-                .block_when_full = config.block_when_full,
+                .soft_limit = config.soft_limit,
                 .chunk_pool = Pool.init(allocator, config.max_pool_size),
                 .is_closed = false,
                 .reset_id = 0,
@@ -251,34 +256,51 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
             self.chunk_pool.deinit(self.allocator);
         }
 
-        /// Push a single item (fiber-safe, cancelable)
-        /// Enforce the size limit for `needed` additional items; blocks
-        /// waiting for readers when configured to do so. Assumes the mutex
-        /// is held; may release it while waiting.
-        fn reserveSpaceLocked(self: *Self, needed: usize) (Io.Cancelable || PushError)!void {
+        /// Enforce the size limit for `needed` additional items. Never
+        /// blocks; assumes the mutex is held.
+        fn reserveSpaceLocked(self: *Self, needed: usize) PushError!void {
             if (self.max_size == 0) return;
 
             const max_items = self.max_size / @sizeOf(T);
-            if (needed > max_items) {
-                // Can never fit, waiting would deadlock
-                return PushError.OutOfMemory;
-            }
 
-            if (!self.block_when_full) {
+            if (self.soft_limit) {
+                // High-water mark: an append into an empty queue may
+                // overshoot (e.g. a single frame larger than the limit).
+                if (self.items_available == 0) return;
                 if (self.items_available + needed > max_items) {
-                    return PushError.OutOfMemory;
+                    return PushError.NoSpace;
                 }
                 return;
             }
 
-            while (!self.is_closed and self.items_available + needed > max_items) {
-                try self.space_cond.wait(self.io, &self.mutex);
-            }
-            if (self.is_closed) {
-                return PushError.Closed;
+            if (needed > max_items or self.items_available + needed > max_items) {
+                return PushError.OutOfMemory;
             }
         }
 
+        /// Wait until `needed` more items fit under the soft limit, until
+        /// the queue is empty (a lone oversized append is always allowed),
+        /// or until the queue is closed. No space is reserved: the caller
+        /// must retry its append and may need to wait again.
+        pub fn waitForSpace(self: *Self, needed: usize) (Io.Cancelable || error{Closed})!void {
+            try self.mutex.lock(self.io);
+            defer self.mutex.unlock(self.io);
+
+            if (self.max_size == 0) return;
+            const max_items = self.max_size / @sizeOf(T);
+
+            while (!self.is_closed and
+                self.items_available != 0 and
+                self.items_available + needed > max_items)
+            {
+                try self.space_cond.wait(self.io, &self.mutex);
+            }
+            if (self.is_closed) {
+                return error.Closed;
+            }
+        }
+
+        /// Push a single item (fiber-safe, cancelable)
         pub fn push(self: *Self, item: T) (Io.Cancelable || PushError)!void {
             try self.mutex.lock(self.io);
             defer self.mutex.unlock(self.io);
@@ -287,7 +309,11 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return PushError.Closed;
             }
 
-            try self.reserveSpaceLocked(1);
+            // Soft-limited queues only meter bulk appends (appendMany);
+            // single items and slices are small control data.
+            if (!self.soft_limit) {
+                try self.reserveSpaceLocked(1);
+            }
 
             const chunk = try self.ensureWritableChunk();
             const success = chunk.pushItem(item);
@@ -310,7 +336,10 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
                 return PushError.Closed;
             }
 
-            try self.reserveSpaceLocked(items.len);
+            // See push: control-sized appends bypass a soft limit.
+            if (!self.soft_limit) {
+                try self.reserveSpaceLocked(items.len);
+            }
 
             var remaining = items;
             var total_written: usize = 0;
@@ -386,7 +415,7 @@ pub fn ConcurrentQueue(comptime T: type, comptime chunk_size: usize) type {
 
         /// Wake writers waiting for space. Assumes the mutex is held.
         fn notifySpaceLocked(self: *Self) void {
-            if (self.block_when_full and self.max_size > 0) {
+            if (self.soft_limit and self.max_size > 0) {
                 self.space_cond.broadcast(self.io);
             }
         }
@@ -841,15 +870,10 @@ pub fn ConcurrentWriteBuffer(comptime chunk_size: usize) type {
                     return PushError.ChunkLimitExceeded;
                 }
             }
-            if (dest.queue.max_size > 0) {
-                const max_items = dest.queue.max_size / @sizeOf(u8);
-                if (dest.queue.items_available >= max_items) {
-                    return PushError.OutOfMemory;
-                }
-                if (self.queue.items_available > max_items - dest.queue.items_available) {
-                    return PushError.OutOfMemory;
-                }
-            }
+            // Note: dest.max_size is deliberately not enforced here. The
+            // chunks are already allocated; splicing them frees the source
+            // without allocating on the destination, and rejecting the
+            // reconnect-buffer transfer would strand buffered publishes.
 
             // Splice self's list onto dest's list. The destination tail must
             // be sealed: an unsealed chunk with a successor can neither be
@@ -1474,52 +1498,65 @@ test "VectorGather detects concurrent consumer advancing buffer" {
     try std.testing.expectError(error.ConcurrentConsumer, gather.consume(3));
 }
 
-test "blocking append waits for space" {
+test "soft limit meters bulk appends with NoSpace" {
     const allocator = std.testing.allocator;
 
     const Buffer = ConcurrentWriteBuffer(16);
-    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .block_when_full = true });
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .soft_limit = true });
     defer buffer.deinit();
 
-    try buffer.append("12345678"); // exactly full
+    try buffer.appendMany(&.{"1234"});
+    try buffer.appendMany(&.{"5678"}); // exactly at the limit
+
+    // Over the high-water mark: bulk appends are rejected with NoSpace...
+    try std.testing.expectError(PushError.NoSpace, buffer.appendMany(&.{"x"}));
+
+    // ...but control-sized appends always go through (overshoot allowed).
+    try buffer.append("PING");
+    try std.testing.expectEqual(@as(usize, 12), buffer.queue.getItemsAvailable());
+
+    // Drain completely; a lone bulk append larger than the whole limit is
+    // then accepted (high-water mark, not a hard cap).
+    var view = try buffer.getSlice(.{ .duration = .{ .raw = .zero, .clock = .awake } });
+    view.consume(12);
+    try buffer.appendMany(&.{"0123456789abcde"});
+    try std.testing.expectEqual(@as(usize, 15), buffer.queue.getItemsAvailable());
+}
+
+test "waitForSpace returns when space is freed" {
+    const allocator = std.testing.allocator;
+
+    const Buffer = ConcurrentWriteBuffer(16);
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .soft_limit = true });
+    defer buffer.deinit();
+
+    try buffer.appendMany(&.{"12345678"}); // full
 
     const Helper = struct {
         fn consumer(io: std.Io, buf: *Buffer) void {
-            // Give the appender time to block, then free space.
             io.sleep(.fromMilliseconds(20), .awake) catch return;
             var view = buf.getSlice(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } }) catch return;
-            view.consume(4);
+            view.consume(8);
         }
     };
 
     var consumer_task = try std.testing.io.concurrent(Helper.consumer, .{ std.testing.io, &buffer });
     defer consumer_task.cancel(std.testing.io);
 
-    // Blocks until the consumer frees 4 bytes.
-    try buffer.append("abcd");
-
-    try std.testing.expectEqual(@as(usize, 8), buffer.queue.getItemsAvailable());
+    // Blocks until the consumer frees space, then the retry fits.
+    try buffer.queue.waitForSpace(4);
+    try buffer.appendMany(&.{"abcd"});
+    try std.testing.expectEqual(@as(usize, 4), buffer.queue.getItemsAvailable());
 }
 
-test "blocking append larger than capacity fails" {
+test "close wakes waitForSpace" {
     const allocator = std.testing.allocator;
 
     const Buffer = ConcurrentWriteBuffer(16);
-    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .block_when_full = true });
+    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .soft_limit = true });
     defer buffer.deinit();
 
-    // Could never fit, must fail instead of blocking forever.
-    try std.testing.expectError(PushError.OutOfMemory, buffer.append("123456789"));
-}
-
-test "close wakes a blocked appender" {
-    const allocator = std.testing.allocator;
-
-    const Buffer = ConcurrentWriteBuffer(16);
-    var buffer = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .block_when_full = true });
-    defer buffer.deinit();
-
-    try buffer.append("12345678"); // full
+    try buffer.appendMany(&.{"12345678"}); // full
 
     const Helper = struct {
         fn closer(io: std.Io, buf: *Buffer) void {
@@ -1531,7 +1568,7 @@ test "close wakes a blocked appender" {
     var closer_task = try std.testing.io.concurrent(Helper.closer, .{ std.testing.io, &buffer });
     defer closer_task.cancel(std.testing.io);
 
-    try std.testing.expectError(PushError.Closed, buffer.append("more"));
+    try std.testing.expectError(error.Closed, buffer.queue.waitForSpace(4));
 }
 
 test "non-blocking append still fails when full" {
@@ -1543,4 +1580,22 @@ test "non-blocking append still fails when full" {
 
     try buffer.append("12345678");
     try std.testing.expectError(PushError.OutOfMemory, buffer.append("x"));
+}
+
+test "moveToBuffer ignores the destination size limit" {
+    const allocator = std.testing.allocator;
+
+    const Buffer = ConcurrentWriteBuffer(16);
+    var src = Buffer.init(allocator, std.testing.io, .{});
+    defer src.deinit();
+    var dest = Buffer.init(allocator, std.testing.io, .{ .max_size = 8, .soft_limit = true });
+    defer dest.deinit();
+
+    // More data than the destination limit: the transfer must still
+    // succeed, the chunks are already allocated.
+    try src.append("0123456789abcdefghijklmnopqrstuv"); // 32 bytes
+    try src.moveToBuffer(&dest);
+
+    try std.testing.expectEqual(@as(usize, 0), src.queue.getItemsAvailable());
+    try std.testing.expectEqual(@as(usize, 32), dest.queue.getItemsAvailable());
 }

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -67,6 +67,9 @@ pub const Subscription = struct {
     pending_bytes_limit: std.atomic.Value(u64) = std.atomic.Value(u64).init(default_pending_bytes_limit),
     dropped_msgs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     slow_consumer: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    // Armed on every drop; consumed by the next synchronous receive, which
+    // reports it as error.SlowConsumer
+    sc_error_pending: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     // Autounsubscribe state
     max_msgs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0), // 0 means no limit
@@ -311,6 +314,12 @@ pub const Subscription = struct {
 
     pub const ReceiveError = Io.Cancelable || error{
         ConnectionClosed,
+        /// Messages were dropped for this subscription since the previous
+        /// receive because a pending limit was exceeded. Returned once per
+        /// drop burst, at the position of the gap in the stream; the next
+        /// call receives messages again (nats.go behavior). See `dropped()`
+        /// for exact loss accounting.
+        SlowConsumer,
     };
 
     pub const ReceiveTimeoutError = ReceiveError || Io.Timeout.Error;
@@ -330,6 +339,13 @@ pub const Subscription = struct {
     }
 
     fn nextMsgInternal(self: *Subscription, timeout: Io.Timeout) ReceiveTimeoutError!*Message {
+        // Report dropped messages in-band, at the stream position of the
+        // gap, so synchronous consumers learn about the loss even without
+        // a slow_consumer_cb.
+        if (self.sc_error_pending.swap(false, .acq_rel)) {
+            return error.SlowConsumer;
+        }
+
         // Check if subscription has reached autounsubscribe limit
         const max = self.max_msgs.load(.acquire);
         if (max > 0 and self.delivered_msgs.load(.acquire) >= max) {

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -67,8 +67,9 @@ pub const Subscription = struct {
     pending_bytes_limit: std.atomic.Value(u64) = std.atomic.Value(u64).init(default_pending_bytes_limit),
     dropped_msgs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     slow_consumer: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
-    // Armed on every drop; consumed by the next synchronous receive, which
-    // reports it as error.SlowConsumer
+    // Armed when a synchronous subscription enters a slow-consumer episode;
+    // consumed by the next synchronous receive. Multiple episodes before a
+    // receive coalesce into one report; dropped_msgs provides the exact count.
     sc_error_pending: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     // Autounsubscribe state
@@ -314,11 +315,10 @@ pub const Subscription = struct {
 
     pub const ReceiveError = Io.Cancelable || error{
         ConnectionClosed,
-        /// Messages were dropped for this subscription since the previous
-        /// receive because a pending limit was exceeded. Returned once per
-        /// drop burst, at the position of the gap in the stream; the next
-        /// call receives messages again (nats.go behavior). See `dropped()`
-        /// for exact loss accounting.
+        /// One or more messages were dropped for this subscription because a
+        /// pending limit was exceeded. Reports the start of a slow-consumer
+        /// episode; multiple episodes may coalesce if the error is not
+        /// consumed between them. See `dropped()` for exact loss accounting.
         SlowConsumer,
     };
 
@@ -339,9 +339,8 @@ pub const Subscription = struct {
     }
 
     fn nextMsgInternal(self: *Subscription, timeout: Io.Timeout) ReceiveTimeoutError!*Message {
-        // Report dropped messages in-band, at the stream position of the
-        // gap, so synchronous consumers learn about the loss even without
-        // a slow_consumer_cb.
+        // Report dropped messages in-band so synchronous consumers learn
+        // about the loss even without a slow_consumer_cb.
         if (self.sc_error_pending.swap(false, .acq_rel)) {
             return error.SlowConsumer;
         }

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -214,14 +214,15 @@ pub const Subscription = struct {
 
     /// Set the pending limits for this subscription (0 = unlimited).
     /// Messages arriving while a limit is exceeded are dropped and counted
-    /// in `dropped()`, and the connection's error callback is notified.
+    /// in `dropped()`, and the connection's `slow_consumer_cb` is notified
+    /// once per slow-consumer episode.
     pub fn setPendingLimits(self: *Subscription, msgs_limit: u32, bytes_limit: u64) void {
         self.pending_msgs_limit.store(msgs_limit, .release);
         self.pending_bytes_limit.store(bytes_limit, .release);
     }
 
-    /// Number of known messages dropped for this subscription because a
-    /// pending limit was exceeded (or a message could not be enqueued).
+    /// Number of messages dropped for this subscription because a pending
+    /// limit was exceeded.
     pub fn dropped(self: *const Subscription) u64 {
         return self.dropped_msgs.load(.acquire);
     }

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -60,6 +60,14 @@ pub const Subscription = struct {
     pending_msgs: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     pending_bytes: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
+    // Slow-consumer protection: when either pending limit is exceeded,
+    // incoming messages for this subscription are dropped and counted
+    // (0 = unlimited). Defaults match nats.go.
+    pending_msgs_limit: std.atomic.Value(u32) = std.atomic.Value(u32).init(default_pending_msgs_limit),
+    pending_bytes_limit: std.atomic.Value(u64) = std.atomic.Value(u64).init(default_pending_bytes_limit),
+    dropped_msgs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    slow_consumer: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
     // Autounsubscribe state
     max_msgs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0), // 0 means no limit
     delivered_msgs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
@@ -69,6 +77,10 @@ pub const Subscription = struct {
     drain_complete: xsync.Event = .init,
 
     pub const MessageQueue = ConcurrentQueue(*Message, 1024); // 1K chunk size
+
+    // Default pending limits, matching nats.go.
+    pub const default_pending_msgs_limit: u32 = 500_000;
+    pub const default_pending_bytes_limit: u64 = 64 * 1024 * 1024;
 
     pub fn create(nc: *Connection, sid: u64, subject: []const u8, queue_group: ?[]const u8, handler: ?MsgHandler) !*Subscription {
         const sub = try nc.allocator.create(Subscription);
@@ -198,6 +210,20 @@ pub const Subscription = struct {
         self.messages.deinit();
 
         self.nc.allocator.destroy(self);
+    }
+
+    /// Set the pending limits for this subscription (0 = unlimited).
+    /// Messages arriving while a limit is exceeded are dropped and counted
+    /// in `dropped()`, and the connection's error callback is notified.
+    pub fn setPendingLimits(self: *Subscription, msgs_limit: u32, bytes_limit: u64) void {
+        self.pending_msgs_limit.store(msgs_limit, .release);
+        self.pending_bytes_limit.store(bytes_limit, .release);
+    }
+
+    /// Number of known messages dropped for this subscription because a
+    /// pending limit was exceeded (or a message could not be enqueued).
+    pub fn dropped(self: *const Subscription) u64 {
+        return self.dropped_msgs.load(.acquire);
     }
 
     pub fn retain(self: *Subscription) void {

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -160,3 +160,56 @@ test "JetStream synchronous queue subscription basic functionality" {
     // Verify message content
     try testing.expectEqualStrings(test_message, js_msg.msg.data);
 }
+
+test "JetStream subscriptions are exempt from slow-consumer drops" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+
+    const stream_name = try utils.generateUniqueStreamName(std.testing.allocator);
+    defer std.testing.allocator.free(stream_name);
+    const subject_filter = try utils.generateSubjectFromStreamName(std.testing.allocator, stream_name);
+    defer std.testing.allocator.free(subject_filter);
+
+    var stream_info = try js.addStream(.{
+        .name = stream_name,
+        .subjects = &.{subject_filter},
+    });
+    defer stream_info.deinit();
+
+    // A consumer without acks has no server-side in-flight bound and no
+    // redelivery: its delivery subscription must have unlimited pending.
+    var no_ack_sub = try js.subscribeSync(subject_filter, .{
+        .stream = stream_name,
+        .config = .{ .ack_policy = .none, .max_ack_pending = 0 },
+    });
+    defer no_ack_sub.deinit();
+
+    try std.testing.expectEqual(@as(u32, 0), no_ack_sub.subscription.pending_msgs_limit.load(.acquire));
+    try std.testing.expectEqual(@as(u64, 0), no_ack_sub.subscription.pending_bytes_limit.load(.acquire));
+
+    // With acks, the pending limits must cover the server's full
+    // in-flight window (max_ack_pending), so a drop cannot happen.
+    var big_window_sub = try js.subscribeSync(subject_filter, .{
+        .stream = stream_name,
+        .durable = "big_window",
+        .config = .{ .ack_policy = .explicit, .max_ack_pending = 600_000 },
+    });
+    defer big_window_sub.deinit();
+
+    try std.testing.expectEqual(@as(u32, 600_000), big_window_sub.subscription.pending_msgs_limit.load(.acquire));
+    try std.testing.expect(big_window_sub.subscription.pending_bytes_limit.load(.acquire) >= 600_000 * 1024 * 1024);
+
+    // A default-sized ack window keeps the default limits.
+    var default_sub = try js.subscribeSync(subject_filter, .{
+        .stream = stream_name,
+        .durable = "default_window",
+        .config = .{ .ack_policy = .explicit },
+    });
+    defer default_sub.deinit();
+
+    try std.testing.expectEqual(nats.Subscription.default_pending_msgs_limit, default_sub.subscription.pending_msgs_limit.load(.acquire));
+}

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -161,7 +161,7 @@ test "JetStream synchronous queue subscription basic functionality" {
     try testing.expectEqualStrings(test_message, js_msg.msg.data);
 }
 
-test "JetStream subscriptions are exempt from slow-consumer drops" {
+test "JetStream pending limits remain bounded and track large ack windows" {
     const io = std.testing.io;
 
     const conn = try utils.createDefaultConnection(io);
@@ -180,19 +180,20 @@ test "JetStream subscriptions are exempt from slow-consumer drops" {
     });
     defer stream_info.deinit();
 
-    // A consumer without acks has no server-side in-flight bound and no
-    // redelivery: its delivery subscription must have unlimited pending.
+    // AckNone has no redelivery safety, but it must remain bounded: otherwise
+    // an unread subscription recreates the unbounded-memory problem.
     var no_ack_sub = try js.subscribeSync(subject_filter, .{
         .stream = stream_name,
         .config = .{ .ack_policy = .none, .max_ack_pending = 0 },
     });
     defer no_ack_sub.deinit();
 
-    try std.testing.expectEqual(@as(u32, 0), no_ack_sub.subscription.pending_msgs_limit.load(.acquire));
-    try std.testing.expectEqual(@as(u64, 0), no_ack_sub.subscription.pending_bytes_limit.load(.acquire));
+    try std.testing.expectEqual(nats.Subscription.default_pending_msgs_limit, no_ack_sub.subscription.pending_msgs_limit.load(.acquire));
+    try std.testing.expectEqual(nats.Subscription.default_pending_bytes_limit, no_ack_sub.subscription.pending_bytes_limit.load(.acquire));
 
-    // With acks, the pending limits must cover the server's full
-    // in-flight window (max_ack_pending), so a drop cannot happen.
+    // Match nats.go by raising the client message limit when the server's
+    // max-ack-pending window exceeds the default. This reduces avoidable
+    // client-side drops without claiming that MaxAckPending guarantees none.
     var big_window_sub = try js.subscribeSync(subject_filter, .{
         .stream = stream_name,
         .durable = "big_window",

--- a/tests/pending_msgs_test.zig
+++ b/tests/pending_msgs_test.zig
@@ -139,3 +139,80 @@ test "pending_msgs counter async subscription" {
     const expected_bytes = msg1_data.len + msg2_data.len + msg3_data.len;
     try std.testing.expect(total_bytes_processed.load(.acquire) == expected_bytes);
 }
+
+const SlowConsumerTracker = struct {
+    var error_count: std.atomic.Value(u32) = .init(0);
+
+    fn errorCallback(_: *nats.Connection, _: []const u8) void {
+        _ = error_count.fetchAdd(1, .monotonic);
+    }
+};
+
+test "slow consumer drops messages over the pending message limit" {
+    const io = std.testing.io;
+
+    SlowConsumerTracker.error_count.store(0, .monotonic);
+
+    var conn = try utils.createConnection(io, .node1, .{
+        .callbacks = .{ .error_cb = SlowConsumerTracker.errorCallback },
+    });
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("test.slowconsumer.msgs");
+    defer sub.deinit();
+    sub.setPendingLimits(2, 0);
+
+    for (0..5) |_| {
+        try conn.publish("test.slowconsumer.msgs", "payload");
+    }
+    try conn.flush();
+
+    // All five messages were processed by the reader before flush returned:
+    // two delivered, three dropped, one slow-consumer episode reported.
+    try std.testing.expectEqual(@as(u32, 2), sub.pending_msgs.load(.acquire));
+    try std.testing.expectEqual(@as(u64, 3), sub.dropped());
+    try std.testing.expectEqual(@as(u32, 1), SlowConsumerTracker.error_count.load(.monotonic));
+
+    // Consuming ends the episode; new messages are delivered again.
+    for (0..2) |_| {
+        const msg = try sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });
+        msg.deinit();
+    }
+
+    try conn.publish("test.slowconsumer.msgs", "after");
+    try conn.flush();
+
+    const msg = try sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });
+    defer msg.deinit();
+    try std.testing.expectEqualStrings("after", msg.data);
+
+    // A second overflow is a new episode with its own callback.
+    for (0..5) |_| {
+        try conn.publish("test.slowconsumer.msgs", "payload");
+    }
+    try conn.flush();
+
+    try std.testing.expectEqual(@as(u32, 2), SlowConsumerTracker.error_count.load(.monotonic));
+    try std.testing.expect(sub.dropped() > 3);
+}
+
+test "slow consumer drops messages over the pending bytes limit" {
+    const io = std.testing.io;
+
+    var conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("test.slowconsumer.bytes");
+    defer sub.deinit();
+    sub.setPendingLimits(0, 10);
+
+    // 8 bytes fit; the second and third message would exceed 10 bytes.
+    for (0..3) |_| {
+        try conn.publish("test.slowconsumer.bytes", "8bytes!!");
+    }
+    try conn.flush();
+
+    try std.testing.expectEqual(@as(u32, 1), sub.pending_msgs.load(.acquire));
+    try std.testing.expectEqual(@as(u64, 8), sub.pending_bytes.load(.acquire));
+    try std.testing.expectEqual(@as(u64, 2), sub.dropped());
+}

--- a/tests/pending_msgs_test.zig
+++ b/tests/pending_msgs_test.zig
@@ -141,20 +141,25 @@ test "pending_msgs counter async subscription" {
 }
 
 const SlowConsumerTracker = struct {
-    var error_count: std.atomic.Value(u32) = .init(0);
+    var episode_count: std.atomic.Value(u32) = .init(0);
+    var last_sub: std.atomic.Value(usize) = .init(0);
+    var last_dropped: std.atomic.Value(u64) = .init(0);
 
-    fn errorCallback(_: *nats.Connection, _: []const u8) void {
-        _ = error_count.fetchAdd(1, .monotonic);
+    fn slowConsumerCallback(_: *nats.Connection, sub: *nats.Subscription, dropped_count: u64) void {
+        last_sub.store(@intFromPtr(sub), .release);
+        last_dropped.store(dropped_count, .release);
+        _ = episode_count.fetchAdd(1, .monotonic);
     }
 };
 
 test "slow consumer drops messages over the pending message limit" {
     const io = std.testing.io;
 
-    SlowConsumerTracker.error_count.store(0, .monotonic);
+    SlowConsumerTracker.episode_count.store(0, .monotonic);
+    SlowConsumerTracker.last_sub.store(0, .monotonic);
 
     var conn = try utils.createConnection(io, .node1, .{
-        .callbacks = .{ .error_cb = SlowConsumerTracker.errorCallback },
+        .callbacks = .{ .slow_consumer_cb = SlowConsumerTracker.slowConsumerCallback },
     });
     defer utils.closeConnection(conn);
 
@@ -171,7 +176,11 @@ test "slow consumer drops messages over the pending message limit" {
     // two delivered, three dropped, one slow-consumer episode reported.
     try std.testing.expectEqual(@as(u32, 2), sub.pending_msgs.load(.acquire));
     try std.testing.expectEqual(@as(u64, 3), sub.dropped());
-    try std.testing.expectEqual(@as(u32, 1), SlowConsumerTracker.error_count.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), SlowConsumerTracker.episode_count.load(.monotonic));
+    // The callback identifies the subscription and reports the dropped
+    // count at the start of the episode.
+    try std.testing.expectEqual(@intFromPtr(sub), SlowConsumerTracker.last_sub.load(.acquire));
+    try std.testing.expectEqual(@as(u64, 1), SlowConsumerTracker.last_dropped.load(.acquire));
 
     // Consuming ends the episode; new messages are delivered again.
     for (0..2) |_| {
@@ -192,7 +201,7 @@ test "slow consumer drops messages over the pending message limit" {
     }
     try conn.flush();
 
-    try std.testing.expectEqual(@as(u32, 2), SlowConsumerTracker.error_count.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 2), SlowConsumerTracker.episode_count.load(.monotonic));
     try std.testing.expect(sub.dropped() > 3);
 }
 
@@ -215,4 +224,29 @@ test "slow consumer drops messages over the pending bytes limit" {
     try std.testing.expectEqual(@as(u32, 1), sub.pending_msgs.load(.acquire));
     try std.testing.expectEqual(@as(u64, 8), sub.pending_bytes.load(.acquire));
     try std.testing.expectEqual(@as(u64, 2), sub.dropped());
+}
+
+test "publish larger than the write buffer limit succeeds" {
+    const io = std.testing.io;
+
+    // A tiny high-water mark: a single message far above it must still be
+    // published (the limit is not a hard cap on message size).
+    var conn = try utils.createConnection(io, .node1, .{
+        .write_buffer_limit = 64,
+    });
+    defer utils.closeConnection(conn);
+
+    const sub = try conn.subscribeSync("test.bigpayload");
+    defer sub.deinit();
+
+    const payload = try std.testing.allocator.alloc(u8, 16 * 1024);
+    defer std.testing.allocator.free(payload);
+    @memset(payload, 'x');
+
+    try conn.publish("test.bigpayload", payload);
+    try conn.flush();
+
+    const msg = try sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });
+    defer msg.deinit();
+    try std.testing.expectEqual(payload.len, msg.data.len);
 }

--- a/tests/pending_msgs_test.zig
+++ b/tests/pending_msgs_test.zig
@@ -182,14 +182,22 @@ test "slow consumer drops messages over the pending message limit" {
     try std.testing.expectEqual(@intFromPtr(sub), SlowConsumerTracker.last_sub.load(.acquire));
     try std.testing.expectEqual(@as(u64, 1), SlowConsumerTracker.last_dropped.load(.acquire));
 
-    // The first receive after the drops reports the gap in-band, exactly
-    // once; the queued messages are still delivered afterwards.
+    // The first receive after the drops reports the episode in-band; the
+    // queued messages are still delivered afterwards.
     try std.testing.expectError(
         error.SlowConsumer,
         sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } }),
     );
 
-    // Consuming ends the episode; new messages are delivered again.
+    // Another drop while still in the same episode must not re-arm the error
+    // and starve delivery of the messages already in the queue.
+    try conn.publish("test.slowconsumer.msgs", "still-full");
+    try conn.flush();
+    try std.testing.expectEqual(@as(u64, 4), sub.dropped());
+    try std.testing.expectEqual(@as(u32, 1), SlowConsumerTracker.episode_count.load(.monotonic));
+
+    // Draining the queued messages makes room. The next successful enqueue
+    // ends the episode, allowing a later overflow to report a new one.
     for (0..2) |_| {
         const msg = try sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });
         msg.deinit();

--- a/tests/pending_msgs_test.zig
+++ b/tests/pending_msgs_test.zig
@@ -182,6 +182,13 @@ test "slow consumer drops messages over the pending message limit" {
     try std.testing.expectEqual(@intFromPtr(sub), SlowConsumerTracker.last_sub.load(.acquire));
     try std.testing.expectEqual(@as(u64, 1), SlowConsumerTracker.last_dropped.load(.acquire));
 
+    // The first receive after the drops reports the gap in-band, exactly
+    // once; the queued messages are still delivered afterwards.
+    try std.testing.expectError(
+        error.SlowConsumer,
+        sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } }),
+    );
+
     // Consuming ends the episode; new messages are delivered again.
     for (0..2) |_| {
         const msg = try sub.nextMsgTimeout(.{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });


### PR DESCRIPTION
## Summary

Finding 4 from the static review (design in `notes/bounded-queues-plan.md`), in two halves:

**Per-subscription pending limits (slow-consumer protection).** Limits are measured on message counts and payload bytes via the existing `pending_msgs`/`pending_bytes` counters — never on queue storage, since the queue stores pointers. Defaults 500k msgs / 64MB match nats.go; `setPendingLimits(msgs, bytes)` adjusts per subscription, 0 = unlimited. Over-limit messages are dropped and counted in `dropped()`. Each slow-consumer episode is reported once (transition-edge) through a dedicated `slow_consumer_cb(*Connection, *Subscription, dropped)` — invoked outside locks with the subscription retained — so the application knows exactly which subscription lost messages. A real allocation failure while enqueueing remains a connection error, per the plan; only configured limit violations drop.

**Bounded live write buffer with backpressure.** New `write_buffer_limit` option (8MB default, 0 = unlimited), treated as a **high-water mark**:

- publishers attempt the append under `Connection.mutex`; on `NoSpace` they wait **outside all connection locks** (`waitForSpace`) and retry against re-checked connection state — so reconnect and close can always proceed, and all three of consumption, buffer reset (reconnect), and close (delivers `ConnectionClosed`) wake the waiters
- a single message larger than the whole limit is accepted into an empty buffer (the limit never rejects a publish the server would allow)
- small control frames (PING, PONG, SUB, UNSUB, CONNECT) always go through
- `moveToBuffer` does not enforce the destination limit: reconnect-buffer chunks are already allocated, and rejecting the transfer would strand buffered publishes
- the reconnect `pending_buffer` keeps its existing bounded, error-when-full behavior (`reconnect_buf_size`)

Groundwork intentionally left for a follow-up: replacing the chunked write buffer with a fixed byte ring now that it is bounded.

## Validation

- `./check.sh` passed (fmt, unit, full e2e)
- queue unit tests: NoSpace metering with control-frame bypass, oversized-append-into-empty, waitForSpace woken by consumption, close waking waiters, strict (pending-buffer) mode unchanged, moveToBuffer over-limit transfer
- e2e: message-count and byte limits against a real server (exact pending/dropped counts, one callback per episode identifying the subscription, delivery resuming after drain), and a publish 256× larger than the configured limit succeeding
