### PR TITLE
Fix reconnect configuration and attempt accounting

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -520,6 +520,10 @@ pub const Connection = struct {
             return;
         }
 
+        // A terminal reconnect failure already reported closure through
+        // failTerminally; don't fire the closed callback a second time.
+        const already_reported = self.status == .connection_failed;
+
         // Mark the connection as permanently closed
         self.status = .closed;
         self.status_cond.broadcast(self.io);
@@ -532,8 +536,10 @@ pub const Connection = struct {
         self.pong_condition.broadcast(self.io);
 
         // Make sure we invoke the closed callback
-        if (self.options.callbacks.closed_cb) |cb| {
-            callback = cb;
+        if (!already_reported) {
+            if (self.options.callbacks.closed_cb) |cb| {
+                callback = cb;
+            }
         }
     }
 
@@ -905,7 +911,7 @@ pub const Connection = struct {
         defer self.mutex.unlock(self.io);
 
         while (self.status != .connected) {
-            if (self.status == .closed) {
+            if (self.status == .closed or self.status == .connection_failed) {
                 log.debug("Flush skipped, no longer connected", .{});
                 return error.ConnectionClosed;
             }
@@ -1045,6 +1051,15 @@ pub const Connection = struct {
 
         var attempts: u32 = 0;
 
+        // Number of explicitly configured servers; the pool itself shrinks
+        // as servers exceed max_reconnect, so the initial-connect iteration
+        // must not compare against the live size.
+        const initial_pool_size = blk: {
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
+            break :blk self.server_pool.getSize();
+        };
+
         while (true) {
             var conn_err: ?anyerror = null;
             self.runConnection(&attempts) catch |err| {
@@ -1076,12 +1091,12 @@ pub const Connection = struct {
                 }
 
                 if (self.status == .connecting) {
-                    // Initial connection: try each server in the pool once
-                    // (selectNextServer rotates through it), then report the
-                    // failure through connect(). No callbacks fire here; the
-                    // connection was never established.
+                    // Initial connection: try each configured server once
+                    // (selectNextServer rotates through the pool), then
+                    // report the failure through connect(). No callbacks
+                    // fire here; the connection was never established.
                     attempts += 1;
-                    if (pool_exhausted or attempts >= self.server_pool.getSize()) {
+                    if (pool_exhausted or attempts >= initial_pool_size) {
                         return;
                     }
                     continue;
@@ -1090,6 +1105,11 @@ pub const Connection = struct {
                 if (pool_exhausted or !self.options.reconnect.allow_reconnect) {
                     // Terminal; handled outside the mutex below.
                 } else {
+                    // The disconnected callback fires only when an
+                    // established connection is lost, not after every
+                    // failed reconnection attempt.
+                    const was_established = self.status == .connected;
+
                     self.status = .reconnecting;
                     self.status_cond.broadcast(self.io);
 
@@ -1100,8 +1120,10 @@ pub const Connection = struct {
                     // and flusher tasks are already joined at this point.
                     self.write_buffer.reset();
 
-                    if (self.options.callbacks.disconnected_cb) |cb| {
-                        callback = cb;
+                    if (was_established) {
+                        if (self.options.callbacks.disconnected_cb) |cb| {
+                            callback = cb;
+                        }
                     }
                 }
             }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -459,7 +459,17 @@ pub const Connection = struct {
         self.status = .connecting;
         self.status_cond.broadcast(self.io);
 
-        _ = try self.server_pool.addServer(url, false);
+        // The URL may be a comma-separated list of servers; the initial
+        // connection tries them in order until one succeeds.
+        var added: usize = 0;
+        var url_it = std.mem.splitScalar(u8, url, ',');
+        while (url_it.next()) |part| {
+            const trimmed = std.mem.trim(u8, part, " \t");
+            if (trimmed.len == 0) continue;
+            _ = try self.server_pool.addServer(trimmed, false);
+            added += 1;
+        }
+        if (added == 0) return error.InvalidUrl;
 
         try self.manager_task.concurrent(self.io, managerTask, .{self});
         errdefer self.manager_task.cancel(self.io);
@@ -1042,10 +1052,16 @@ pub const Connection = struct {
                     return err;
                 }
                 if (err == error.ShouldClose) {
+                    // Deliberate give-up (e.g. repeated auth failures):
+                    // terminal, the disconnected callback already fired
+                    // when reconnection started.
+                    self.failTerminally(false);
                     return;
                 }
                 conn_err = err;
             };
+
+            const pool_exhausted = if (conn_err) |err| err == error.NoServerAvailable else false;
 
             var callback: @TypeOf(self.options.callbacks.disconnected_cb) = null;
 
@@ -1060,22 +1076,50 @@ pub const Connection = struct {
                 }
 
                 if (self.status == .connecting) {
-                    return;
+                    // Initial connection: try each server in the pool once
+                    // (selectNextServer rotates through it), then report the
+                    // failure through connect(). No callbacks fire here; the
+                    // connection was never established.
+                    attempts += 1;
+                    if (pool_exhausted or attempts >= self.server_pool.getSize()) {
+                        return;
+                    }
+                    continue;
                 }
 
-                self.status = .reconnecting;
-                self.status_cond.broadcast(self.io);
+                if (pool_exhausted or !self.options.reconnect.allow_reconnect) {
+                    // Terminal; handled outside the mutex below.
+                } else {
+                    self.status = .reconnecting;
+                    self.status_cond.broadcast(self.io);
 
-                // Discard whatever was buffered for the dead socket. This
-                // also wakes publishers blocked in waitForSpace, so they
-                // re-check the status and reroute into pending_buffer
-                // instead of waiting out the whole reconnect. The reader
-                // and flusher tasks are already joined at this point.
-                self.write_buffer.reset();
+                    // Discard whatever was buffered for the dead socket. This
+                    // also wakes publishers blocked in waitForSpace, so they
+                    // re-check the status and reroute into pending_buffer
+                    // instead of waiting out the whole reconnect. The reader
+                    // and flusher tasks are already joined at this point.
+                    self.write_buffer.reset();
 
-                if (self.options.callbacks.disconnected_cb) |cb| {
-                    callback = cb;
+                    if (self.options.callbacks.disconnected_cb) |cb| {
+                        callback = cb;
+                    }
                 }
+            }
+
+            if (pool_exhausted) {
+                // Every server exceeded max_reconnect and was removed from
+                // the pool. The disconnected callback fired when
+                // reconnection started.
+                log.warn("No servers left to reconnect to, giving up", .{});
+                self.failTerminally(false);
+                return;
+            }
+            if (!self.options.reconnect.allow_reconnect) {
+                // Fresh connection loss with reconnection disabled: report
+                // both the disconnect and the final closed state.
+                log.info("Reconnection is disabled, closing connection", .{});
+                self.failTerminally(true);
+                return;
             }
 
             if (callback) |cb| cb(self);
@@ -1089,6 +1133,38 @@ pub const Connection = struct {
                 try self.io.sleep(delay, .awake);
             }
         }
+    }
+
+    /// Take the connection to the terminal connection_failed state: no
+    /// further reconnection attempts will be made. Closes the buffers so
+    /// blocked publishers and drain waiters wake up, and fires the
+    /// disconnected (optionally) and closed callbacks, unless the user
+    /// already closed the connection.
+    fn failTerminally(self: *Self, fire_disconnected: bool) void {
+        var disconnected_cb: @TypeOf(self.options.callbacks.disconnected_cb) = null;
+        var closed_cb: @TypeOf(self.options.callbacks.closed_cb) = null;
+
+        {
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
+
+            if (self.status == .closed) return;
+
+            self.status = .connection_failed;
+            self.status_cond.broadcast(self.io);
+
+            if (fire_disconnected) {
+                disconnected_cb = self.options.callbacks.disconnected_cb;
+            }
+            closed_cb = self.options.callbacks.closed_cb;
+        }
+
+        // Wake anything blocked on the buffers (publishers, flush waiters).
+        self.pending_buffer.close();
+        self.write_buffer.close();
+
+        if (disconnected_cb) |cb| cb(self);
+        if (closed_cb) |cb| cb(self);
     }
 
     fn selectNextServer(self: *Self) !*Server {
@@ -1117,9 +1193,11 @@ pub const Connection = struct {
 
         std.debug.assert(self.status == .connecting or self.status == .reconnecting);
 
-        // Setup connection state
+        // Setup connection state. The reconnect counter is deliberately not
+        // reset here: a server that accepts TCP but fails the NATS handshake
+        // must still count against max_reconnect (the counter is reset after
+        // a successful handshake).
         server.did_connect = true;
-        server.reconnects = 0;
 
         // Reset parser for clean state
         self.parser.reset();
@@ -1195,6 +1273,7 @@ pub const Connection = struct {
             return err;
         };
         server.last_auth_error = null;
+        server.reconnects = 0;
         if (self.status == .reconnecting) {
             was_reconnect = true;
         }

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -12,6 +12,7 @@ test {
     _ = @import("drain_test.zig");
     _ = @import("core_request_reply_test.zig");
     _ = @import("reconnection_test.zig");
+    _ = @import("reconnect_limits_test.zig");
     _ = @import("keepalive_test.zig");
     _ = @import("jetstream_test.zig");
     _ = @import("jetstream_stream_test.zig");

--- a/tests/reconnect_limits_test.zig
+++ b/tests/reconnect_limits_test.zig
@@ -1,0 +1,126 @@
+const std = @import("std");
+const nats = @import("nats");
+const utils = @import("utils.zig");
+
+const testing = std.testing;
+
+// Port for the in-test fake server; outside the range used by the
+// docker-compose servers (14222-14229) and the keepalive test (14239).
+const fake_server_port = 14238;
+
+/// Serves one successful NATS handshake and then drops the connection;
+/// every later accepted connection is closed immediately, so each
+/// reconnection attempt fails its handshake after TCP succeeds.
+const FlakyServer = struct {
+    var accepts: std.atomic.Value(u32) = .init(0);
+
+    fn run(io: std.Io, listener: *std.Io.net.Server) void {
+        var first = true;
+        while (true) {
+            var stream = listener.accept(io) catch return;
+            _ = accepts.fetchAdd(1, .monotonic);
+
+            if (!first) {
+                // Accept TCP, then refuse the handshake.
+                stream.close(io);
+                continue;
+            }
+            first = false;
+            serveHandshakeThenDrop(io, &stream);
+        }
+    }
+
+    fn serveHandshakeThenDrop(io: std.Io, stream: *std.Io.net.Stream) void {
+        defer stream.close(io);
+
+        var read_buf: [4096]u8 = undefined;
+        var write_buf: [256]u8 = undefined;
+        var stream_reader = stream.reader(io, &read_buf);
+        var stream_writer = stream.writer(io, &write_buf);
+        const reader = &stream_reader.interface;
+        const writer = &stream_writer.interface;
+
+        writer.writeAll("INFO {\"max_payload\":1048576}\r\n") catch return;
+        writer.flush() catch return;
+
+        // Answer the handshake PING, completing the connection, then
+        // return, which closes the socket and drops the client.
+        while (true) {
+            const data = reader.buffered();
+            if (std.mem.indexOfScalar(u8, data, '\n')) |i| {
+                const is_ping = std.mem.startsWith(u8, data[0..i], "PING");
+                reader.toss(i + 1);
+                if (is_ping) {
+                    writer.writeAll("PONG\r\n") catch return;
+                    writer.flush() catch return;
+                    return;
+                }
+                continue;
+            }
+            reader.fillMore() catch return;
+        }
+    }
+};
+
+const ClosedTracker = struct {
+    var closed_called: std.atomic.Value(u32) = .init(0);
+    var reconnected_called: std.atomic.Value(u32) = .init(0);
+
+    fn closedCallback(_: *nats.Connection) void {
+        _ = closed_called.fetchAdd(1, .monotonic);
+    }
+
+    fn reconnectedCallback(_: *nats.Connection) void {
+        _ = reconnected_called.fetchAdd(1, .monotonic);
+    }
+};
+
+test "handshake failures count against max_reconnect" {
+    const io = std.testing.io;
+
+    FlakyServer.accepts.store(0, .monotonic);
+    ClosedTracker.closed_called.store(0, .monotonic);
+    ClosedTracker.reconnected_called.store(0, .monotonic);
+
+    const address: std.Io.net.IpAddress = .{ .ip4 = .loopback(fake_server_port) };
+    var listener = try address.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+
+    var server_task = try io.concurrent(FlakyServer.run, .{ io, &listener });
+    defer server_task.cancel(io);
+
+    const url = std.fmt.comptimePrint("nats://127.0.0.1:{d}", .{fake_server_port});
+    const nc = try utils.createConnectionWithUrl(io, url, .{
+        // Keep failed handshakes quick: the flaky server closes the socket
+        // without answering, and the handshake only fails via this timeout.
+        .timeout = .{ .duration = .{ .raw = .fromMilliseconds(250), .clock = .awake } },
+        .reconnect = .{
+            .allow_reconnect = true,
+            .max_reconnect = 2,
+            .reconnect_wait = .fromMilliseconds(50),
+            .reconnect_jitter = .fromMilliseconds(10),
+        },
+        .callbacks = .{
+            .closed_cb = ClosedTracker.closedCallback,
+            .reconnected_cb = ClosedTracker.reconnectedCallback,
+        },
+    });
+    defer utils.closeConnection(nc);
+
+    // The server drops us right after the handshake. Every reconnection
+    // attempt connects at the TCP level but fails the handshake; those
+    // failures must count against max_reconnect, so after 2 attempts the
+    // server is removed from the pool and the connection goes terminal.
+    const start = std.Io.Timestamp.now(io, .awake);
+    while (nc.status != .connection_failed) {
+        if (start.untilNow(io, .awake).nanoseconds >= 10 * std.time.ns_per_s) {
+            return error.NeverWentTerminal;
+        }
+        try io.sleep(.fromMilliseconds(50), .awake);
+    }
+
+    // Initial connection plus exactly max_reconnect failed attempts.
+    try testing.expectEqual(@as(u32, 3), FlakyServer.accepts.load(.monotonic));
+    try testing.expectEqual(@as(u32, 1), ClosedTracker.closed_called.load(.monotonic));
+    try testing.expectEqual(@as(u32, 0), ClosedTracker.reconnected_called.load(.monotonic));
+}

--- a/tests/reconnect_limits_test.zig
+++ b/tests/reconnect_limits_test.zig
@@ -65,6 +65,7 @@ const FlakyServer = struct {
 const ClosedTracker = struct {
     var closed_called: std.atomic.Value(u32) = .init(0);
     var reconnected_called: std.atomic.Value(u32) = .init(0);
+    var disconnected_called: std.atomic.Value(u32) = .init(0);
 
     fn closedCallback(_: *nats.Connection) void {
         _ = closed_called.fetchAdd(1, .monotonic);
@@ -72,6 +73,10 @@ const ClosedTracker = struct {
 
     fn reconnectedCallback(_: *nats.Connection) void {
         _ = reconnected_called.fetchAdd(1, .monotonic);
+    }
+
+    fn disconnectedCallback(_: *nats.Connection) void {
+        _ = disconnected_called.fetchAdd(1, .monotonic);
     }
 };
 
@@ -81,6 +86,7 @@ test "handshake failures count against max_reconnect" {
     FlakyServer.accepts.store(0, .monotonic);
     ClosedTracker.closed_called.store(0, .monotonic);
     ClosedTracker.reconnected_called.store(0, .monotonic);
+    ClosedTracker.disconnected_called.store(0, .monotonic);
 
     const address: std.Io.net.IpAddress = .{ .ip4 = .loopback(fake_server_port) };
     var listener = try address.listen(io, .{ .reuse_address = true });
@@ -103,6 +109,7 @@ test "handshake failures count against max_reconnect" {
         .callbacks = .{
             .closed_cb = ClosedTracker.closedCallback,
             .reconnected_cb = ClosedTracker.reconnectedCallback,
+            .disconnected_cb = ClosedTracker.disconnectedCallback,
         },
     });
     defer utils.closeConnection(nc);
@@ -123,4 +130,7 @@ test "handshake failures count against max_reconnect" {
     try testing.expectEqual(@as(u32, 3), FlakyServer.accepts.load(.monotonic));
     try testing.expectEqual(@as(u32, 1), ClosedTracker.closed_called.load(.monotonic));
     try testing.expectEqual(@as(u32, 0), ClosedTracker.reconnected_called.load(.monotonic));
+    // The disconnected callback reports losing the established connection
+    // once; failed reconnection attempts must not re-fire it.
+    try testing.expectEqual(@as(u32, 1), ClosedTracker.disconnected_called.load(.monotonic));
 }

--- a/tests/reconnection_test.zig
+++ b/tests/reconnection_test.zig
@@ -326,25 +326,38 @@ test "no automatic reconnection when disabled" {
         try io.sleep(.fromMilliseconds(50), .awake);
     }
 
-    tracker.mutex.lockUncancelable(std.testing.io);
-    defer tracker.mutex.unlock(std.testing.io);
-    try testing.expectEqual(@as(u32, 1), tracker.disconnected_called);
-    try testing.expectEqual(@as(u32, 1), tracker.closed_called);
-    try testing.expectEqual(@as(u32, 0), tracker.reconnected_called);
+    {
+        tracker.mutex.lockUncancelable(std.testing.io);
+        defer tracker.mutex.unlock(std.testing.io);
+        try testing.expectEqual(@as(u32, 1), tracker.disconnected_called);
+        try testing.expectEqual(@as(u32, 1), tracker.closed_called);
+        try testing.expectEqual(@as(u32, 0), tracker.reconnected_called);
+    }
 
-    // Publishing on a failed connection is rejected.
+    // Publishing on a failed connection is rejected, and flush must not
+    // hang waiting for a reconnection that will never happen.
     try testing.expectError(error.ConnectionClosed, nc.publish("test.noreconnect", "after"));
+    try testing.expectError(error.ConnectionClosed, nc.flush());
+
+    // Closing after a terminal failure must not fire closed_cb again.
+    nc.close();
+    {
+        tracker.mutex.lockUncancelable(std.testing.io);
+        defer tracker.mutex.unlock(std.testing.io);
+        try testing.expectEqual(@as(u32, 1), tracker.closed_called);
+    }
 }
 
 test "initial connect iterates the server pool" {
     const io = std.testing.io;
 
-    // The first address refuses connections (reserved unused port); the
-    // initial connection must fail over to the second.
+    // The first two addresses refuse connections (unused ports); the
+    // initial connection must try every configured server, even with
+    // max_reconnect low enough to shrink the pool while iterating.
     const nc = try utils.createConnectionWithUrl(
         io,
-        "nats://127.0.0.1:14226, nats://127.0.0.1:14222",
-        .{},
+        "nats://127.0.0.1:14226, nats://127.0.0.1:14237, nats://127.0.0.1:14222",
+        .{ .reconnect = .{ .max_reconnect = 0 } },
     );
     defer utils.closeConnection(nc);
 

--- a/tests/reconnection_test.zig
+++ b/tests/reconnection_test.zig
@@ -293,3 +293,61 @@ test "reconnect() errors when connection closed" {
 
     try testing.expectError(error.ConnectionClosed, nc.reconnect());
 }
+
+test "no automatic reconnection when disabled" {
+    const io = std.testing.io;
+
+    tracker.reset();
+
+    const nc = try utils.createConnection(io, .node1, .{
+        .reconnect = .{
+            .allow_reconnect = false,
+        },
+        .callbacks = .{
+            .disconnected_cb = CallbackTracker.disconnectedCallback,
+            .reconnected_cb = CallbackTracker.reconnectedCallback,
+            .closed_cb = CallbackTracker.closedCallback,
+        },
+    });
+    defer utils.closeConnection(nc);
+
+    try nc.publish("test.noreconnect", "before restart");
+    try nc.flush();
+
+    log.debug("Restarting nats-1", .{});
+    try utils.runDockerCompose(std.testing.allocator, &.{ "restart", "nats-1" });
+
+    // The connection must go terminal instead of reconnecting.
+    const start = std.Io.Timestamp.now(io, .awake);
+    while (nc.status != .connection_failed) {
+        if (start.untilNow(io, .awake).nanoseconds >= 10 * std.time.ns_per_s) {
+            return error.TerminalStateTimeout;
+        }
+        try io.sleep(.fromMilliseconds(50), .awake);
+    }
+
+    tracker.mutex.lockUncancelable(std.testing.io);
+    defer tracker.mutex.unlock(std.testing.io);
+    try testing.expectEqual(@as(u32, 1), tracker.disconnected_called);
+    try testing.expectEqual(@as(u32, 1), tracker.closed_called);
+    try testing.expectEqual(@as(u32, 0), tracker.reconnected_called);
+
+    // Publishing on a failed connection is rejected.
+    try testing.expectError(error.ConnectionClosed, nc.publish("test.noreconnect", "after"));
+}
+
+test "initial connect iterates the server pool" {
+    const io = std.testing.io;
+
+    // The first address refuses connections (reserved unused port); the
+    // initial connection must fail over to the second.
+    const nc = try utils.createConnectionWithUrl(
+        io,
+        "nats://127.0.0.1:14226, nats://127.0.0.1:14222",
+        .{},
+    );
+    defer utils.closeConnection(nc);
+
+    try nc.publish("test.pool.failover", "made it");
+    try nc.flush();
+}


### PR DESCRIPTION
## Summary

Finding 5 from the static review, four related fixes:

- **`allow_reconnect = false` is honored by automatic reconnection.** It previously only affected manual `reconnect()` and publish routing; the manager loop reconnected regardless. Connection loss now goes terminal: status `connection_failed`, buffers closed (waking any publisher blocked on the write-buffer high-water mark from #145), `disconnected_cb` then `closed_cb`.
- **`server.reconnects` resets after a successful handshake, not after TCP connect.** A server that accepts TCP but rejects or stalls the NATS handshake used to reset its own counter on every attempt, so `max_reconnect` could never trip (the old total-attempts bound that masked this was removed in ab11dce). The reset now sits at the same point where `last_auth_error` is cleared.
- **Pool exhaustion is terminal.** `getNextServer` removes servers that exceed `max_reconnect`; an empty pool previously produced `NoServerAvailable` on every iteration, forever. It now ends in `connection_failed` with `closed_cb`. The repeated-auth-error give-up (`ShouldClose`) goes through the same terminal path, so it also closes buffers and fires `closed_cb` now.
- **`connect()` accepts a comma-separated URL list** (the standard seed-list format of nats.go/nats.c), and the initial connection tries each pool server once — previously it gave up after the first server, and only one could be configured anyway.

Terminal-by-failure is deliberately `connection_failed`, distinguishable from user-initiated `close()`.

## Validation

- `./check.sh` passed (fmt, unit, full e2e)
- new tests: reconnect-disabled goes terminal after a server restart (callbacks asserted, no reconnect); initial connect fails over from a dead address in a two-server URL list; and a fake flaky server (one good handshake, then TCP-accept-but-refuse-handshake forever) must reach `connection_failed` after exactly `max_reconnect` attempts — verified to spin forever on main (`NeverWentTerminal`)