### PR TITLE
Fix terminal connection lifetime semantics

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -228,6 +228,7 @@ const ExitReason = enum(u8) {
     reader_done,
     flusher_done,
     reconnect_requested,
+    close_requested,
 };
 
 /// One-shot exit signal owned by a single `runConnection` iteration. The
@@ -390,8 +391,15 @@ pub const Connection = struct {
         };
     }
 
+    /// Destroy the connection after joining all of its tasks.
+    ///
+    /// Do not call deinit() from a connection callback: callbacks may run on
+    /// a connection-owned task, and an object cannot destroy the task that is
+    /// currently executing it. Calling close() from callbacks is supported;
+    /// call deinit() later from the connection's owner.
     pub fn deinit(self: *Self) void {
         self.close();
+        self.manager_task.cancel(self.io);
 
         // Clean up response manager
         self.response_manager.deinit();
@@ -522,7 +530,13 @@ pub const Connection = struct {
         _ = try self.server_pool.addServer(url, false);
     }
 
-    /// Close the connection
+    /// Close the connection.
+    ///
+    /// This is safe to call from any connection callback. It performs the
+    /// terminal state transition and wakes all operations, but deliberately
+    /// does not join manager_task: a callback may itself be running in that
+    /// task (or in a reader task the manager is joining). deinit() is the
+    /// synchronous join-and-destroy boundary.
     pub fn close(self: *Self) void {
         var callback: @TypeOf(self.options.callbacks.closed_cb) = null;
 
@@ -543,13 +557,12 @@ pub const Connection = struct {
         self.status_cond.broadcast(self.io);
         self.handshake_cond.broadcast(self.io);
         self.pong_condition.broadcast(self.io);
+        if (self.exit_signal) |signal| {
+            signal.signal(self.io, .close_requested, null);
+        }
         self.mutex.unlock(self.io);
 
         self.closeWaiters();
-
-        // The state change and waiter wakeups happen first so manager and
-        // operation tasks can observe closure while they are being joined.
-        self.manager_task.cancel(self.io);
 
         // A failed connection already emitted closed_cb from failTerminally,
         // while a never-started/never-established connection has never been
@@ -1174,13 +1187,18 @@ pub const Connection = struct {
 
             if (callback) |cb| cb(self);
 
+            // A callback may close the connection. Do not enter a reconnect
+            // delay (or make another attempt) after it returns.
+            const status = self.getStatus();
+            if (status == .closed or status == .connection_failed) return;
+
             // Wait before the next attempt; the first retry after losing an
             // established connection is immediate.
             attempts += 1;
             if (attempts > 1) {
                 const delay = self.calculateReconnectDelay(attempts - 1);
                 log.debug("Waiting {f} before reconnection attempt {}", .{ delay, attempts });
-                try self.io.sleep(delay, .awake);
+                if (!try self.waitForReconnectDelay(delay)) return;
             }
         }
     }
@@ -1433,6 +1451,7 @@ pub const Connection = struct {
             .reconnect_requested => {
                 log.info("Reconnect requested", .{});
             },
+            .close_requested => {},
         }
     }
 
@@ -1997,6 +2016,24 @@ pub const Connection = struct {
         return delay;
     }
 
+    /// Wait for a reconnect delay while remaining immediately interruptible
+    /// by close(). Returns false when the connection became terminal.
+    fn waitForReconnectDelay(self: *Self, delay: Io.Duration) !bool {
+        const deadline = io_util.deadline(self.io, .{ .duration = .{ .raw = delay, .clock = .awake } });
+
+        try self.mutex.lock(self.io);
+        defer self.mutex.unlock(self.io);
+
+        while (self.status == .reconnecting and !io_util.expired(self.io, deadline)) {
+            self.status_cond.waitTimeout(self.io, &self.mutex, deadline) catch |err| switch (err) {
+                error.Canceled => |e| return e,
+                error.Timeout => {},
+            };
+        }
+
+        return self.status != .closed and self.status != .connection_failed;
+    }
+
     fn resendSubscriptions(self: *Self) !void {
         log.debug("Re-establishing subscriptions", .{});
 
@@ -2353,4 +2390,154 @@ test "terminal connection failure wakes all operation waiters exactly once" {
     connection.close();
     try std.testing.expectEqual(@as(u32, 1), CallbackCounter.disconnected.load(.monotonic));
     try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+}
+
+test "close is reentrant from manager callbacks" {
+    const CallbackCounter = struct {
+        var disconnected: std.atomic.Value(u32) = .init(0);
+        var reconnected: std.atomic.Value(u32) = .init(0);
+        var closed: std.atomic.Value(u32) = .init(0);
+
+        fn onDisconnected(connection: *Connection) void {
+            _ = disconnected.fetchAdd(1, .monotonic);
+            connection.close();
+        }
+
+        fn onReconnected(connection: *Connection) void {
+            _ = reconnected.fetchAdd(1, .monotonic);
+            connection.close();
+        }
+
+        fn onClosed(connection: *Connection) void {
+            _ = closed.fetchAdd(1, .monotonic);
+            connection.close();
+        }
+    };
+    const ManagerCallbacks = struct {
+        fn terminal(connection: *Connection) Io.Cancelable!void {
+            connection.failTerminally(true);
+        }
+
+        fn reconnected(connection: *Connection) Io.Cancelable!void {
+            connection.options.callbacks.reconnected_cb.?(connection);
+        }
+    };
+
+    const io = std.testing.io;
+    CallbackCounter.disconnected.store(0, .monotonic);
+    CallbackCounter.reconnected.store(0, .monotonic);
+    CallbackCounter.closed.store(0, .monotonic);
+
+    // Terminal callbacks execute in manager_task in production. Both
+    // callbacks close recursively; joining manager_task from close() would
+    // make this task wait for itself forever.
+    {
+        var connection = Connection.init(std.testing.allocator, io, .{
+            .callbacks = .{
+                .disconnected_cb = CallbackCounter.onDisconnected,
+                .closed_cb = CallbackCounter.onClosed,
+            },
+        });
+        defer connection.deinit();
+        connection.status = .connected;
+
+        try connection.manager_task.concurrent(io, ManagerCallbacks.terminal, .{&connection});
+        try connection.manager_task.await(io);
+
+        try std.testing.expectEqual(ConnectionStatus.closed, connection.getStatus());
+        try std.testing.expectEqual(@as(u32, 1), CallbackCounter.disconnected.load(.monotonic));
+        try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+    }
+
+    // reconnected_cb is also invoked directly by manager_task.
+    {
+        var connection = Connection.init(std.testing.allocator, io, .{
+            .callbacks = .{
+                .reconnected_cb = CallbackCounter.onReconnected,
+                .closed_cb = CallbackCounter.onClosed,
+            },
+        });
+        defer connection.deinit();
+        connection.status = .connected;
+
+        try connection.manager_task.concurrent(io, ManagerCallbacks.reconnected, .{&connection});
+        try connection.manager_task.await(io);
+
+        try std.testing.expectEqual(ConnectionStatus.closed, connection.getStatus());
+        try std.testing.expectEqual(@as(u32, 1), CallbackCounter.reconnected.load(.monotonic));
+        try std.testing.expectEqual(@as(u32, 2), CallbackCounter.closed.load(.monotonic));
+    }
+}
+
+test "close is safe from a reader error callback" {
+    const CallbackCounter = struct {
+        var errors: std.atomic.Value(u32) = .init(0);
+        var closed: std.atomic.Value(u32) = .init(0);
+
+        fn onError(connection: *Connection, _: []const u8) void {
+            _ = errors.fetchAdd(1, .monotonic);
+            connection.close();
+        }
+
+        fn onClosed(connection: *Connection) void {
+            _ = closed.fetchAdd(1, .monotonic);
+            connection.close();
+        }
+    };
+    const Tasks = struct {
+        fn reader(connection: *Connection) void {
+            connection.options.callbacks.error_cb.?(connection, "test error");
+        }
+
+        fn manager(connection: *Connection) Io.Cancelable!void {
+            var reader_task = connection.io.concurrent(reader, .{connection}) catch @panic("failed to start test reader");
+            defer reader_task.cancel(connection.io);
+            reader_task.await(connection.io);
+        }
+    };
+
+    const io = std.testing.io;
+    CallbackCounter.errors.store(0, .monotonic);
+    CallbackCounter.closed.store(0, .monotonic);
+
+    var connection = Connection.init(std.testing.allocator, io, .{
+        .callbacks = .{
+            .error_cb = CallbackCounter.onError,
+            .closed_cb = CallbackCounter.onClosed,
+        },
+    });
+    defer connection.deinit();
+    connection.status = .connected;
+
+    // The manager owns and awaits the reader, matching runConnection. A
+    // synchronous manager cancel from the reader callback creates a join
+    // cycle: reader -> manager -> reader.
+    try connection.manager_task.concurrent(io, Tasks.manager, .{&connection});
+    try connection.manager_task.await(io);
+
+    try std.testing.expectEqual(ConnectionStatus.closed, connection.getStatus());
+    try std.testing.expectEqual(@as(u32, 1), CallbackCounter.errors.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+}
+
+test "close interrupts reconnect delay" {
+    const Result = enum(u8) { pending, interrupted, unexpected };
+    const Task = struct {
+        fn run(connection: *Connection, result: *std.atomic.Value(Result)) Io.Cancelable!void {
+            const retry = try connection.waitForReconnectDelay(.fromSeconds(60));
+            result.store(if (retry) .unexpected else .interrupted, .release);
+        }
+    };
+
+    const io = std.testing.io;
+    var connection = Connection.init(std.testing.allocator, io, .{});
+    defer connection.deinit();
+    connection.status = .reconnecting;
+
+    var result: std.atomic.Value(Result) = .init(.pending);
+    try connection.manager_task.concurrent(io, Task.run, .{ &connection, &result });
+    connection.close();
+    try connection.manager_task.await(io);
+
+    try std.testing.expectEqual(Result.interrupted, result.load(.acquire));
 }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -434,6 +434,10 @@ pub const Connection = struct {
 
     pub fn connect(self: *Self, url: []const u8) !void {
         errdefer self.close();
+        // Registered before the mutex-unlock defer below, so error unwinding
+        // releases the mutex before synchronously joining the manager task.
+        var manager_started = false;
+        errdefer if (manager_started) self.manager_task.cancel(self.io);
 
         try io_util.ensureAwakeClock(self.io);
 
@@ -491,7 +495,7 @@ pub const Connection = struct {
         if (added == 0) return error.InvalidUrl;
 
         try self.manager_task.concurrent(self.io, managerTask, .{self});
-        errdefer self.manager_task.cancel(self.io);
+        manager_started = true;
 
         while (true) {
             if (self.status == .closed) return error.ConnectionClosed;
@@ -611,11 +615,11 @@ pub const Connection = struct {
                 log.info("Already reconnecting, ignoring manual reconnect request", .{});
                 return ConnectionError.AlreadyReconnecting;
             },
-            .initialized, .closed => {
+            .initialized, .closed, .connection_failed => {
                 log.warn("Cannot reconnect: connection is closed", .{});
                 return ConnectionError.ConnectionClosed;
             },
-            .connecting, .connection_failed => {
+            .connecting => {
                 log.warn("Cannot reconnect: initial connection not yet established", .{});
                 return ConnectionError.NotConnected;
             },
@@ -932,6 +936,7 @@ pub const Connection = struct {
 
         if (self.subscriptions.fetchRemove(sid)) |kv| {
             log.debug("Removed subscription {d} ({s}) from connection", .{ sid, kv.value.subject });
+            kv.value.closeFromConnection();
             // Release connection's reference to the subscription
             kv.value.release();
         }
@@ -2382,12 +2387,32 @@ test "terminal connection failure wakes all operation waiters exactly once" {
     try std.testing.expectEqual(Result.connection_closed, subscription_drain_result.load(.acquire));
     try std.testing.expectEqual(@as(u32, 1), CallbackCounter.disconnected.load(.monotonic));
     try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+    try std.testing.expectError(error.ConnectionClosed, connection.reconnect());
 
     // Repeated terminal paths must not repeat callbacks.
     connection.failTerminally(true);
     connection.close();
     try std.testing.expectEqual(@as(u32, 1), CallbackCounter.disconnected.load(.monotonic));
     try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+}
+
+test "detaching a subscription wakes its drain waiter" {
+    const io = std.testing.io;
+    var connection = Connection.init(std.testing.allocator, io, .{});
+    defer connection.deinit();
+    connection.status = .connected;
+
+    const subscription = try connection.subscribeSync("lifetime.detached-drain");
+    defer subscription.deinit();
+
+    // Keep drain pending, then detach the subscription from the connection's
+    // active table. It must become terminal even though closeWaiters can no
+    // longer discover it through that table.
+    subscription_mod.incrementPending(subscription, 0);
+    subscription.drain();
+    connection.removeSubscriptionInternal(subscription.sid);
+
+    try std.testing.expectError(error.ConnectionClosed, subscription.waitForDrainCompletion(.none));
 }
 
 test "close is reentrant from manager callbacks" {
@@ -2449,6 +2474,7 @@ test "close is reentrant from manager callbacks" {
 
     // reconnected_cb is also invoked directly by manager_task.
     {
+        CallbackCounter.closed.store(0, .monotonic);
         var connection = Connection.init(std.testing.allocator, io, .{
             .callbacks = .{
                 .reconnected_cb = CallbackCounter.onReconnected,
@@ -2463,7 +2489,7 @@ test "close is reentrant from manager callbacks" {
 
         try std.testing.expectEqual(ConnectionStatus.closed, connection.getStatus());
         try std.testing.expectEqual(@as(u32, 1), CallbackCounter.reconnected.load(.monotonic));
-        try std.testing.expectEqual(@as(u32, 2), CallbackCounter.closed.load(.monotonic));
+        try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
     }
 }
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -30,7 +30,9 @@ const JetStream = jetstream_mod.JetStream;
 const JetStreamOptions = jetstream_mod.JetStreamOptions;
 const build_options = @import("build_options");
 const ConcurrentWriteBuffer = @import("queue.zig").ConcurrentWriteBuffer;
-const ResponseManager = @import("response_manager.zig").ResponseManager;
+const response_manager_mod = @import("response_manager.zig");
+const ResponseManager = response_manager_mod.ResponseManager;
+const RequestHandle = response_manager_mod.RequestHandle;
 const MAX_CONTROL_LINE_SIZE = @import("parser.zig").MAX_CONTROL_LINE_SIZE;
 const validation = @import("validation.zig");
 const nkeys = @import("nkeys.zig");
@@ -151,6 +153,8 @@ pub const ProtocolError = error{
 };
 
 pub const ConnectionStatus = enum {
+    /// Allocated and ready for its one allowed call to connect().
+    initialized,
     closed,
     connecting,
     connected,
@@ -304,8 +308,12 @@ pub const Connection = struct {
 
     options: ConnectionOptions,
 
-    status: ConnectionStatus = .closed,
+    status: ConnectionStatus = .initialized,
     status_cond: xsync.Condition = .init,
+    /// Latched when the first NATS handshake and restoration complete, so
+    /// connect() cannot miss a short-lived `.connected` state if the socket
+    /// drops again before its waiter reacquires the mutex.
+    connected_once: bool = false,
 
     // Exit signal of the current runConnection iteration (protected by mutex)
     exit_signal: ?*ExitSignal = null,
@@ -451,9 +459,13 @@ pub const Connection = struct {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
 
-        if (self.status != .closed) {
-            log.err("Already connected", .{});
-            return error.AlreadyConnected;
+        switch (self.status) {
+            .initialized => {},
+            .closed, .connection_failed => return error.ConnectionClosed,
+            .connecting, .connected, .reconnecting => {
+                log.err("Already connected", .{});
+                return error.AlreadyConnected;
+            },
         }
 
         self.status = .connecting;
@@ -475,6 +487,12 @@ pub const Connection = struct {
         errdefer self.manager_task.cancel(self.io);
 
         while (true) {
+            if (self.status == .closed) return error.ConnectionClosed;
+            if (self.connected_once) {
+                log.info("Connected successfully", .{});
+                return;
+            }
+
             switch (self.status) {
                 .closed => return error.ConnectionClosed,
                 .connection_failed => {
@@ -485,10 +503,7 @@ pub const Connection = struct {
                     }
                     return error.ConnectionFailed;
                 },
-                .connected => {
-                    log.info("Connected successfully", .{});
-                    return;
-                },
+                .connected => return,
                 else => {
                     try self.status_cond.wait(self.io, &self.mutex);
                 },
@@ -500,47 +515,52 @@ pub const Connection = struct {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
 
+        if (self.status == .closed or self.status == .connection_failed) {
+            return error.ConnectionClosed;
+        }
+
         _ = try self.server_pool.addServer(url, false);
     }
 
     /// Close the connection
     pub fn close(self: *Self) void {
-        // Call the callback outside of mutex, if provided
         var callback: @TypeOf(self.options.callbacks.closed_cb) = null;
-        defer if (callback) |cb| cb(self);
 
         log.info("Closing connection", .{});
 
-        self.manager_task.cancel(self.io);
-
         self.mutex.lockUncancelable(self.io);
-        defer self.mutex.unlock(self.io);
-
         if (self.status == .closed) {
+            self.mutex.unlock(self.io);
             return;
         }
 
-        // A terminal reconnect failure already reported closure through
-        // failTerminally; don't fire the closed callback a second time.
-        const already_reported = self.status == .connection_failed;
+        const previous_status = self.status;
 
-        // Mark the connection as permanently closed
+        // Claim the terminal transition before canceling the manager. This
+        // prevents the manager's cancelation path from racing close() and
+        // reporting a connection failure instead of an explicit close.
         self.status = .closed;
         self.status_cond.broadcast(self.io);
-
-        // Close write buffers to wake up any waiting fibers
-        self.pending_buffer.close();
-        self.write_buffer.close();
-
-        // Wake up any waiting flush() calls
+        self.handshake_cond.broadcast(self.io);
         self.pong_condition.broadcast(self.io);
+        self.mutex.unlock(self.io);
 
-        // Make sure we invoke the closed callback
-        if (!already_reported) {
+        self.closeWaiters();
+
+        // The state change and waiter wakeups happen first so manager and
+        // operation tasks can observe closure while they are being joined.
+        self.manager_task.cancel(self.io);
+
+        // A failed connection already emitted closed_cb from failTerminally,
+        // while a never-started/never-established connection has never been
+        // open and therefore has no close event to report.
+        if (previous_status == .connected or previous_status == .reconnecting) {
             if (self.options.callbacks.closed_cb) |cb| {
                 callback = cb;
             }
         }
+
+        if (callback) |cb| cb(self);
     }
 
     pub fn getStatus(self: *Self) ConnectionStatus {
@@ -580,7 +600,7 @@ pub const Connection = struct {
                 log.info("Already reconnecting, ignoring manual reconnect request", .{});
                 return ConnectionError.AlreadyReconnecting;
             },
-            .closed => {
+            .initialized, .closed => {
                 log.warn("Cannot reconnect: connection is closed", .{});
                 return ConnectionError.ConnectionClosed;
             },
@@ -911,7 +931,7 @@ pub const Connection = struct {
         defer self.mutex.unlock(self.io);
 
         while (self.status != .connected) {
-            if (self.status == .closed or self.status == .connection_failed) {
+            if (self.status == .initialized or self.status == .closed or self.status == .connection_failed) {
                 log.debug("Flush skipped, no longer connected", .{});
                 return error.ConnectionClosed;
             }
@@ -1032,22 +1052,16 @@ pub const Connection = struct {
         self.managerLoop() catch |err| {
             if (err == error.Canceled) return error.Canceled;
             log.err("Manager loop failed: {}", .{err});
+            // All ordinary give-up paths transition explicitly in
+            // managerLoop. This catches unexpected manager failures so they
+            // receive the same wakeup and callback semantics.
+            self.failTerminally(true);
         };
     }
 
     fn managerLoop(self: *Self) anyerror!void {
         log.debug("Manager loop started", .{});
         defer log.debug("Manager loop exited", .{});
-
-        defer {
-            self.mutex.lockUncancelable(self.io);
-            defer self.mutex.unlock(self.io);
-
-            if (self.status != .closed) {
-                self.status = .connection_failed;
-                self.status_cond.broadcast(self.io);
-            }
-        }
 
         var attempts: u32 = 0;
 
@@ -1079,6 +1093,7 @@ pub const Connection = struct {
             const pool_exhausted = if (conn_err) |err| err == error.NoServerAvailable else false;
 
             var callback: @TypeOf(self.options.callbacks.disconnected_cb) = null;
+            var initial_connect_failed = false;
 
             {
                 try self.mutex.lock(self.io);
@@ -1090,6 +1105,13 @@ pub const Connection = struct {
                     log.info("Disconnected", .{});
                 }
 
+                // close() claims the terminal state before canceling the
+                // manager. Never let a concurrently finishing connection
+                // attempt resurrect it as reconnecting.
+                if (self.status == .closed or self.status == .connection_failed) {
+                    return;
+                }
+
                 if (self.status == .connecting) {
                     // Initial connection: try each configured server once
                     // (selectNextServer rotates through the pool), then
@@ -1097,12 +1119,11 @@ pub const Connection = struct {
                     // fire here; the connection was never established.
                     attempts += 1;
                     if (pool_exhausted or attempts >= initial_pool_size) {
-                        return;
+                        initial_connect_failed = true;
+                    } else {
+                        continue;
                     }
-                    continue;
-                }
-
-                if (pool_exhausted or !self.options.reconnect.allow_reconnect) {
+                } else if (pool_exhausted or !self.options.reconnect.allow_reconnect) {
                     // Terminal; handled outside the mutex below.
                 } else {
                     // The disconnected callback fires only when an
@@ -1128,12 +1149,19 @@ pub const Connection = struct {
                 }
             }
 
+            if (initial_connect_failed) {
+                self.failTerminally(false);
+                return;
+            }
+
             if (pool_exhausted) {
                 // Every server exceeded max_reconnect and was removed from
-                // the pool. The disconnected callback fired when
-                // reconnection started.
+                // the pool. If exhaustion happened immediately after an
+                // established connection was lost, this is also the first
+                // opportunity to report the disconnect; failTerminally
+                // suppresses it when reconnecting already reported it.
                 log.warn("No servers left to reconnect to, giving up", .{});
-                self.failTerminally(false);
+                self.failTerminally(true);
                 return;
             }
             if (!self.options.reconnect.allow_reconnect) {
@@ -1170,28 +1198,54 @@ pub const Connection = struct {
             self.mutex.lockUncancelable(self.io);
             defer self.mutex.unlock(self.io);
 
-            if (self.status == .closed) return;
+            if (self.status == .closed or self.status == .connection_failed) return;
+
+            const was_connected = self.status == .connected;
+            const had_established_connection = was_connected or self.status == .reconnecting;
 
             self.status = .connection_failed;
             self.status_cond.broadcast(self.io);
+            self.handshake_cond.broadcast(self.io);
+            self.pong_condition.broadcast(self.io);
 
-            if (fire_disconnected) {
+            if (fire_disconnected and was_connected) {
                 disconnected_cb = self.options.callbacks.disconnected_cb;
             }
-            closed_cb = self.options.callbacks.closed_cb;
+            if (had_established_connection) {
+                closed_cb = self.options.callbacks.closed_cb;
+            }
         }
 
-        // Wake anything blocked on the buffers (publishers, flush waiters).
-        self.pending_buffer.close();
-        self.write_buffer.close();
+        self.closeWaiters();
 
         if (disconnected_cb) |cb| cb(self);
         if (closed_cb) |cb| cb(self);
     }
 
+    /// Permanently stop every operation that can outlive the connection.
+    /// Each component's close operation is idempotent, so explicit close and
+    /// terminal manager failure may safely race to call this.
+    fn closeWaiters(self: *Self) void {
+        self.pending_buffer.close();
+        self.write_buffer.close();
+        self.response_manager.close();
+        self.drain_completion.set(self.io);
+
+        self.subs_mutex.lockUncancelable(self.io);
+        defer self.subs_mutex.unlock(self.io);
+        var iter = self.subscriptions.valueIterator();
+        while (iter.next()) |sub_ptr| {
+            sub_ptr.*.closeFromConnection();
+        }
+    }
+
     fn selectNextServer(self: *Self) !*Server {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
+
+        if (self.status == .closed or self.status == .connection_failed) {
+            return error.ConnectionClosed;
+        }
 
         const server = try self.server_pool.getNextServer(self.options.reconnect.max_reconnect, self.current_server) orelse return error.NoServerAvailable;
         server.reconnects += 1;
@@ -1213,6 +1267,9 @@ pub const Connection = struct {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
 
+        if (self.status == .closed or self.status == .connection_failed) {
+            return error.ConnectionClosed;
+        }
         std.debug.assert(self.status == .connecting or self.status == .reconnecting);
 
         // Setup connection state. The reconnect counter is deliberately not
@@ -1258,6 +1315,9 @@ pub const Connection = struct {
         {
             try self.mutex.lock(self.io);
             defer self.mutex.unlock(self.io);
+            if (self.status == .closed or self.status == .connection_failed) {
+                return error.ConnectionClosed;
+            }
             self.exit_signal = &exit_signal;
         }
         defer {
@@ -1312,7 +1372,11 @@ pub const Connection = struct {
         {
             try self.mutex.lock(self.io);
             defer self.mutex.unlock(self.io);
+            if (self.status == .closed or self.status == .connection_failed) {
+                return error.ConnectionClosed;
+            }
             try self.pending_buffer.moveToBuffer(&self.write_buffer);
+            self.connected_once = true;
             self.status = .connected;
             self.status_cond.broadcast(self.io);
         }
@@ -2007,6 +2071,10 @@ pub const Connection = struct {
         const deadline = io_util.deadline(self.io, self.options.timeout);
 
         while (!self.handshake_state.isFinished()) {
+            if (self.status == .closed or self.status == .connection_failed) {
+                return error.ConnectionClosed;
+            }
+
             log.debug("Handshake state: {}", .{self.handshake_state});
 
             if (io_util.expired(self.io, deadline)) {
@@ -2038,6 +2106,11 @@ pub const Connection = struct {
 
     // Connection draining
     pub fn drain(self: *Self) !void {
+        const status = self.getStatus();
+        if (status == .initialized or status == .closed or status == .connection_failed) {
+            return error.ConnectionClosed;
+        }
+
         const prev_state = self.drain_state.cmpxchgStrong(.not_draining, .draining_subs, .acq_rel, .acquire);
         if (prev_state != null) return; // Already draining
 
@@ -2078,7 +2151,13 @@ pub const Connection = struct {
     pub fn waitForDrainCompletion(self: *Self, timeout: Io.Timeout) !void {
         const state = self.drain_state.load(.acquire);
         switch (state) {
-            .not_draining => return error.NotDraining,
+            .not_draining => {
+                const status = self.getStatus();
+                if (status == .initialized or status == .closed or status == .connection_failed) {
+                    return error.ConnectionClosed;
+                }
+                return error.NotDraining;
+            },
             .drain_complete => return,
             else => {},
         }
@@ -2087,6 +2166,10 @@ pub const Connection = struct {
             try self.drain_completion.wait(self.io);
         } else {
             try self.drain_completion.waitTimeout(self.io, timeout);
+        }
+
+        if (self.drain_state.load(.acquire) != .drain_complete) {
+            return error.ConnectionClosed;
         }
     }
 
@@ -2136,3 +2219,138 @@ pub const Connection = struct {
         };
     }
 };
+
+test "connection can only be connected from its initialized state" {
+    const CallbackCounter = struct {
+        var closed: std.atomic.Value(u32) = .init(0);
+
+        fn onClosed(_: *Connection) void {
+            _ = closed.fetchAdd(1, .monotonic);
+        }
+    };
+
+    const io = std.testing.io;
+    CallbackCounter.closed.store(0, .monotonic);
+
+    var connection = Connection.init(std.testing.allocator, io, .{
+        .callbacks = .{ .closed_cb = CallbackCounter.onClosed },
+    });
+    defer connection.deinit();
+
+    try std.testing.expectEqual(ConnectionStatus.initialized, connection.getStatus());
+
+    connection.close();
+    try std.testing.expectEqual(ConnectionStatus.closed, connection.getStatus());
+    try std.testing.expectError(error.ConnectionClosed, connection.connect("nats://127.0.0.1:4222"));
+
+    // Closing a never-connected object is silent and idempotent.
+    connection.close();
+    try std.testing.expectEqual(@as(u32, 0), CallbackCounter.closed.load(.monotonic));
+}
+
+test "terminal connection failure wakes all operation waiters exactly once" {
+    const Result = enum(u8) {
+        pending,
+        connection_closed,
+        unexpected,
+    };
+    const Waiters = struct {
+        fn saveError(result: *std.atomic.Value(Result), err: anyerror) void {
+            result.store(if (err == error.ConnectionClosed) .connection_closed else .unexpected, .release);
+        }
+
+        fn flush(connection: *Connection, result: *std.atomic.Value(Result)) void {
+            connection.flush() catch |err| return saveError(result, err);
+            result.store(.unexpected, .release);
+        }
+
+        fn response(manager: *ResponseManager, handle: RequestHandle, result: *std.atomic.Value(Result)) void {
+            const msg = manager.waitForResponse(handle, .none) catch |err| return saveError(result, err);
+            msg.deinit();
+            result.store(.unexpected, .release);
+        }
+
+        fn message(subscription: *Subscription, result: *std.atomic.Value(Result)) void {
+            const msg = subscription.nextMsg() catch |err| return saveError(result, err);
+            msg.deinit();
+            result.store(.unexpected, .release);
+        }
+
+        fn drain(connection: *Connection, result: *std.atomic.Value(Result)) void {
+            connection.waitForDrainCompletion(.none) catch |err| return saveError(result, err);
+            result.store(.unexpected, .release);
+        }
+
+        fn subscriptionDrain(subscription: *Subscription, result: *std.atomic.Value(Result)) void {
+            subscription.waitForDrainCompletion(.none) catch |err| return saveError(result, err);
+            result.store(.unexpected, .release);
+        }
+    };
+    const CallbackCounter = struct {
+        var disconnected: std.atomic.Value(u32) = .init(0);
+        var closed: std.atomic.Value(u32) = .init(0);
+
+        fn onDisconnected(_: *Connection) void {
+            _ = disconnected.fetchAdd(1, .monotonic);
+        }
+
+        fn onClosed(_: *Connection) void {
+            _ = closed.fetchAdd(1, .monotonic);
+        }
+    };
+
+    const io = std.testing.io;
+    CallbackCounter.disconnected.store(0, .monotonic);
+    CallbackCounter.closed.store(0, .monotonic);
+
+    var connection = Connection.init(std.testing.allocator, io, .{
+        .timeout = .none,
+        .callbacks = .{
+            .disconnected_cb = CallbackCounter.onDisconnected,
+            .closed_cb = CallbackCounter.onClosed,
+        },
+    });
+    defer connection.deinit();
+    connection.status = .connected;
+
+    const subscription = try connection.subscribeSync("lifetime.waiter");
+    defer subscription.deinit();
+    // Keep one synthetic pending delivery so drain() remains in progress.
+    subscription_mod.incrementPending(subscription, 0);
+    subscription.drain();
+    const request_handle = try connection.response_manager.createRequest();
+    connection.drain_state.store(.draining_pubs, .release);
+
+    var flush_result: std.atomic.Value(Result) = .init(.pending);
+    var response_result: std.atomic.Value(Result) = .init(.pending);
+    var message_result: std.atomic.Value(Result) = .init(.pending);
+    var drain_result: std.atomic.Value(Result) = .init(.pending);
+    var subscription_drain_result: std.atomic.Value(Result) = .init(.pending);
+
+    var waiters: Io.Group = .init;
+    defer waiters.cancel(io);
+    try waiters.concurrent(io, Waiters.flush, .{ &connection, &flush_result });
+    try waiters.concurrent(io, Waiters.response, .{ &connection.response_manager, request_handle, &response_result });
+    try waiters.concurrent(io, Waiters.message, .{ subscription, &message_result });
+    try waiters.concurrent(io, Waiters.drain, .{ &connection, &drain_result });
+    try waiters.concurrent(io, Waiters.subscriptionDrain, .{ subscription, &subscription_drain_result });
+
+    // failTerminally must make progress even when flush has no timeout and
+    // the server never supplies a PONG.
+    connection.failTerminally(true);
+    try waiters.await(io);
+
+    try std.testing.expectEqual(Result.connection_closed, flush_result.load(.acquire));
+    try std.testing.expectEqual(Result.connection_closed, response_result.load(.acquire));
+    try std.testing.expectEqual(Result.connection_closed, message_result.load(.acquire));
+    try std.testing.expectEqual(Result.connection_closed, drain_result.load(.acquire));
+    try std.testing.expectEqual(Result.connection_closed, subscription_drain_result.load(.acquire));
+    try std.testing.expectEqual(@as(u32, 1), CallbackCounter.disconnected.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+
+    // Repeated terminal paths must not repeat callbacks.
+    connection.failTerminally(true);
+    connection.close();
+    try std.testing.expectEqual(@as(u32, 1), CallbackCounter.disconnected.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), CallbackCounter.closed.load(.monotonic));
+}

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -30,9 +30,8 @@ const JetStream = jetstream_mod.JetStream;
 const JetStreamOptions = jetstream_mod.JetStreamOptions;
 const build_options = @import("build_options");
 const ConcurrentWriteBuffer = @import("queue.zig").ConcurrentWriteBuffer;
-const response_manager_mod = @import("response_manager.zig");
-const ResponseManager = response_manager_mod.ResponseManager;
-const RequestHandle = response_manager_mod.RequestHandle;
+const ResponseManager = @import("response_manager.zig").ResponseManager;
+const RequestHandle = @import("response_manager.zig").RequestHandle;
 const MAX_CONTROL_LINE_SIZE = @import("parser.zig").MAX_CONTROL_LINE_SIZE;
 const validation = @import("validation.zig");
 const nkeys = @import("nkeys.zig");
@@ -539,6 +538,7 @@ pub const Connection = struct {
     /// synchronous join-and-destroy boundary.
     pub fn close(self: *Self) void {
         var callback: @TypeOf(self.options.callbacks.closed_cb) = null;
+        defer if (callback) |cb| cb(self);
 
         log.info("Closing connection", .{});
 
@@ -573,7 +573,6 @@ pub const Connection = struct {
             }
         }
 
-        if (callback) |cb| cb(self);
     }
 
     pub fn getStatus(self: *Self) ConnectionStatus {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -572,7 +572,6 @@ pub const Connection = struct {
                 callback = cb;
             }
         }
-
     }
 
     pub fn getStatus(self: *Self) ConnectionStatus {

--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -123,9 +123,23 @@ pub const ResponseManager = struct {
         self.pending_responses.deinit(self.allocator);
     }
 
+    /// Permanently reject new requests and wake requests already waiting for
+    /// a response. Resource destruction remains in deinit(), since the
+    /// response subscription may still have user-visible references.
+    pub fn close(self: *ResponseManager) void {
+        self.pending_mutex.lockUncancelable(self.io);
+        defer self.pending_mutex.unlock(self.io);
+
+        if (self.is_closed) return;
+        self.is_closed = true;
+        self.pending_condition.broadcast(self.io);
+    }
+
     pub fn ensureInitialized(self: *ResponseManager, connection: *Connection) !void {
         try self.pending_mutex.lock(self.io);
         defer self.pending_mutex.unlock(self.io);
+
+        if (self.is_closed) return error.ConnectionClosed;
 
         // Already initialized by another thread
         if (self.resp_mux != null) return;
@@ -458,7 +472,8 @@ test "request handle timeout functionality" {
 
     // Test timeout behavior
     const start = io_util.now(std.testing.io);
-    const result = manager.waitForResponse(handle, .fromMilliseconds(1)); // 1ms timeout
+    const timeout: Io.Timeout = .{ .duration = .{ .raw = .fromMilliseconds(1), .clock = .awake } };
+    const result = manager.waitForResponse(handle, timeout);
     const duration = start.durationTo(io_util.now(std.testing.io)).nanoseconds;
 
     try testing.expectError(error.Timeout, result);
@@ -477,6 +492,7 @@ test "multi-response request creation and timeout" {
     defer manager.cleanupRequest(handle);
 
     // Test timeout behavior for multi-response
-    const result = manager.waitForMultiResponse(handle, .fromMilliseconds(1), .{}); // 1ms timeout
+    const timeout: Io.Timeout = .{ .duration = .{ .raw = .fromMilliseconds(1), .clock = .awake } };
+    const result = manager.waitForMultiResponse(handle, timeout, .{});
     try testing.expectError(error.Timeout, result);
 }

--- a/src/response_manager.zig
+++ b/src/response_manager.zig
@@ -347,6 +347,9 @@ pub const ResponseManager = struct {
 
             if (self.is_closed) {
                 cleanup = true;
+                if (msgs.len > 0) {
+                    return msgs;
+                }
                 return error.ConnectionClosed;
             }
 
@@ -495,4 +498,43 @@ test "multi-response request creation and timeout" {
     const timeout: Io.Timeout = .{ .duration = .{ .raw = .fromMilliseconds(1), .clock = .awake } };
     const result = manager.waitForMultiResponse(handle, timeout, .{});
     try testing.expectError(error.Timeout, result);
+}
+
+test "multi-response returns collected messages when manager closes" {
+    const testing = std.testing;
+    const CloseAfterFirst = struct {
+        var collected: xsync.Event = .init;
+
+        fn keepCollecting(_: *Message) bool {
+            collected.set(std.testing.io);
+            return true;
+        }
+
+        fn close(manager: *ResponseManager) void {
+            collected.wait(std.testing.io) catch return;
+            manager.close();
+        }
+    };
+
+    const io = std.testing.io;
+    var manager = ResponseManager.init(std.testing.allocator, io);
+    defer manager.deinit();
+
+    const handle = try manager.createMultiRequest();
+    defer manager.cleanupRequest(handle);
+
+    var msg = Message.init(std.testing.allocator);
+    msg.subject = "0";
+    msg.data = "partial";
+    try manager.responseHandler(&msg);
+
+    var closer = try io.concurrent(CloseAfterFirst.close, .{&manager});
+    defer closer.cancel(io);
+
+    var messages = try manager.waitForMultiResponse(handle, .none, .{ .sentinelFn = CloseAfterFirst.keepCollecting });
+    closer.await(io);
+    defer while (messages.pop()) |returned| returned.deinit();
+
+    try testing.expectEqual(@as(usize, 1), messages.len);
+    try testing.expectEqualStrings("partial", messages.head.?.data);
 }

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -437,15 +437,15 @@ pub const Subscription = struct {
         // Increment delivered counter with proper memory ordering
         const delivered = self.delivered_msgs.fetchAdd(1, .acq_rel) + 1;
 
+        // Decrement pending counters when message is consumed
+        decrementPending(self, msg.data.len);
+
         // Check if we've reached the autounsubscribe limit
         const max_limit = self.max_msgs.load(.acquire);
         if (max_limit > 0 and delivered >= max_limit) {
             // Remove subscription from connection
             self.nc.removeSubscriptionInternal(self.sid);
         }
-
-        // Decrement pending counters when message is consumed
-        decrementPending(self, msg.data.len);
     }
 };
 

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -79,6 +79,8 @@ pub const Subscription = struct {
     // Drain state
     draining: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     drain_complete: xsync.Event = .init,
+    drain_succeeded: std.atomic.Value(bool) = .init(false),
+    connection_closed: std.atomic.Value(bool) = .init(false),
 
     pub const MessageQueue = ConcurrentQueue(*Message, 1024); // 1K chunk size
 
@@ -216,6 +218,15 @@ pub const Subscription = struct {
         self.nc.allocator.destroy(self);
     }
 
+    /// Wake subscription receivers and drain waiters when their owning
+    /// connection becomes terminal. The subscription object remains valid
+    /// until its normal reference-counted destruction.
+    pub fn closeFromConnection(self: *Subscription) void {
+        self.connection_closed.store(true, .release);
+        self.messages.close();
+        self.drain_complete.set(self.nc.io);
+    }
+
     /// Set the pending limits for this subscription (0 = unlimited).
     /// Messages arriving while a limit is exceeded are dropped and counted
     /// in `dropped()`, and the connection's `slow_consumer_cb` is notified
@@ -270,11 +281,13 @@ pub const Subscription = struct {
     }
 
     pub fn isDrainComplete(self: *Subscription) bool {
-        return self.draining.load(.acquire) and self.drain_complete.isSet();
+        return self.draining.load(.acquire) and self.drain_succeeded.load(.acquire);
     }
 
     /// Wait for the subscription drain to finish.
     pub fn waitForDrainCompletion(self: *Subscription, timeout: Io.Timeout) !void {
+        if (self.drain_succeeded.load(.acquire)) return;
+        if (self.connection_closed.load(.acquire)) return error.ConnectionClosed;
         if (!self.draining.load(.acquire)) {
             return error.NotDraining;
         }
@@ -283,6 +296,10 @@ pub const Subscription = struct {
             try self.drain_complete.wait(self.nc.io);
         } else {
             try self.drain_complete.waitTimeout(self.nc.io, timeout);
+        }
+
+        if (!self.drain_succeeded.load(.acquire)) {
+            return error.ConnectionClosed;
         }
     }
 
@@ -481,7 +498,9 @@ pub fn decrementPending(sub: *Subscription, msg_size: usize) void {
 
     // Check if drain is complete (we just decremented from 1 to 0)
     if (sub.draining.load(.acquire) and remaining_msgs == 1) {
+        if (sub.connection_closed.load(.acquire)) return;
         log.debug("Subscription {d} drain completed", .{sub.sid});
+        sub.drain_succeeded.store(true, .release);
         sub.drain_complete.set(sub.nc.io);
         sub.nc.notifySubscriptionDrainComplete();
     }


### PR DESCRIPTION
## Summary

- add an explicit `initialized` state so a connection can only be connected once
- centralize terminal teardown and wake blocked flush, request, subscription, and drain operations
- make terminal/disconnect/closed callbacks exactly-once
- make `close()` safe from connection callbacks while keeping `deinit()` as the synchronous join-and-destroy boundary
- interrupt reconnect delays and prevent closed connections from being resurrected

## Root cause

`closed` represented both a fresh object and a permanently closed connection, even though the connection-owned queues and task groups are one-shot. Terminal failure also updated status without consistently closing every waiter. Finally, callbacks execute on connection-owned tasks, so a callback calling the old synchronous `close()` could cancel and join its own task.

## Impact

Closed or failed connections are now permanently terminal, blocked operations wake with `error.ConnectionClosed`, callbacks can safely call `close()`, and normal owner-side `deinit()` joins all connection work before destroying resources. Calling `deinit()` directly from a connection callback remains unsupported and is documented.

## Validation

- `zig build test`: 102/102 unit tests and 165/165 integration tests passed
- targeted callback-reentrancy regressions: 3/3 passed
- targeted reconnect-limit/manual-reconnect tests: 2/2 passed
- examples build passed