### PR TITLE
Retry JetStream publishes on no responders

### DIFF
--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -25,6 +25,7 @@ const Connection = @import("connection.zig").Connection;
 const Subscription = @import("subscription.zig").Subscription;
 const subscription_mod = @import("subscription.zig");
 const jetstream_message = @import("jetstream_message.zig");
+const io_util = @import("io_util.zig");
 const inbox = @import("inbox.zig");
 const parseTimestamp = @import("timestamp.zig").parseTimestamp;
 const Result = @import("result.zig").Result;
@@ -382,6 +383,10 @@ pub const PublishOptions = struct {
     expected_last_msg_id: ?[]const u8 = null,
     /// Message time-to-live in nanoseconds
     msg_ttl: ?Io.Duration = null,
+    /// Wait between retries after a NoResponders response.
+    retry_wait: Io.Duration = .fromMilliseconds(250),
+    /// Number of retries after the initial publish attempt.
+    retry_attempts: u32 = 2,
 };
 
 /// Batch of messages returned from fetch operation
@@ -1594,6 +1599,8 @@ pub const JetStream = struct {
 
     /// Internal function to publish a message with header processing
     fn publishMsgInternal(self: JetStream, msg: *Message, options: PublishOptions) !Result(PubAck) {
+        if (options.retry_wait.nanoseconds <= 0) return error.InvalidRetryWait;
+
         // Set JetStream-specific headers based on options
         if (options.msg_id) |id| {
             try msg.headerSet(MsgIdHdr, id);
@@ -1623,15 +1630,25 @@ pub const JetStream = struct {
             try msg.headerSet(MsgTTLHdr, ttl_str);
         }
 
-        // Send request without retry logic
-        // TODO: Implement retry logic for NoResponders (503) errors in clustered environments
-        // See ADR-22: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-22.md
-        // Reference implementations:
-        // - nats.go: 250ms backoff, 2 retries by default
-        // - nats.c: Check their implementation
-        // - nats.java: Check their implementation
-        const resp = self.nc.requestMsg(msg, self.opts.request_timeout) catch |request_err| {
-            return if (request_err == error.NoResponders) error.NoStreamResponse else request_err;
+        const deadline = io_util.deadline(self.nc.io, self.opts.request_timeout);
+        var retries_left = options.retry_attempts;
+        const resp = while (true) {
+            break self.nc.requestMsg(msg, deadline) catch |request_err| switch (request_err) {
+                error.NoResponders => {
+                    if (retries_left == 0) return error.NoStreamResponse;
+                    retries_left -= 1;
+
+                    const remaining = io_util.remaining(self.nc.io, deadline) orelse return error.Timeout;
+                    const retry_wait = if (remaining.nanoseconds < options.retry_wait.nanoseconds)
+                        remaining
+                    else
+                        options.retry_wait;
+                    try self.nc.io.sleep(retry_wait, .awake);
+                    if (io_util.expired(self.nc.io, deadline)) return error.Timeout;
+                    continue;
+                },
+                else => return request_err,
+            };
         };
 
         defer resp.deinit();

--- a/tests/jetstream_test.zig
+++ b/tests/jetstream_test.zig
@@ -688,10 +688,6 @@ test "JetStream publish basic message" {
     var stream_info = try js.addStream(stream_config);
     defer stream_info.deinit();
 
-    // Wait for stream metadata to propagate across cluster nodes
-    // TODO: Remove this delay once retry logic is implemented (see ADR-22)
-    try io.sleep(.fromMilliseconds(100), .awake);
-
     // Publish a message using JetStream publish
     const test_data = "Hello JetStream!";
     var pub_ack = try js.publish(subject, test_data, .{});
@@ -701,6 +697,87 @@ test "JetStream publish basic message" {
     try testing.expectEqualStrings(stream_name, pub_ack.value.stream);
     try testing.expect(pub_ack.value.seq > 0);
     try testing.expect(!pub_ack.value.duplicate);
+}
+
+test "JetStream publish retries while a stream is becoming available" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+
+    const stream_name = try utils.generateUniqueStreamName(testing.allocator);
+    defer testing.allocator.free(stream_name);
+    const stream_subject = try utils.generateSubjectFromStreamName(testing.allocator, stream_name);
+    defer testing.allocator.free(stream_subject);
+    const publish_subject = try std.fmt.allocPrint(testing.allocator, "{s}.message", .{stream_name});
+    defer testing.allocator.free(publish_subject);
+
+    const DelayedCreate = struct {
+        io: std.Io,
+        js: nats.JetStream,
+        stream_name: []const u8,
+        stream_subject: []const u8,
+        err: ?anyerror = null,
+
+        fn run(ctx: *@This()) void {
+            ctx.io.sleep(.fromMilliseconds(100), .awake) catch |err| {
+                ctx.err = err;
+                return;
+            };
+            var info = ctx.js.addStream(.{
+                .name = ctx.stream_name,
+                .subjects = &.{ctx.stream_subject},
+            }) catch |err| {
+                ctx.err = err;
+                return;
+            };
+            info.deinit();
+        }
+    };
+
+    var creator = DelayedCreate{
+        .io = io,
+        .js = js,
+        .stream_name = stream_name,
+        .stream_subject = stream_subject,
+    };
+    var creator_task = try io.concurrent(DelayedCreate.run, .{&creator});
+    defer creator_task.cancel(io);
+
+    var pub_ack = try js.publish(publish_subject, "retried", .{});
+    defer pub_ack.deinit();
+
+    creator_task.await(io);
+    if (creator.err) |err| return err;
+    try testing.expectEqualStrings(stream_name, pub_ack.value.stream);
+}
+
+test "JetStream publish retries respect the overall request timeout" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{
+        .request_timeout = .{ .duration = .{ .raw = .fromMilliseconds(25), .clock = .awake } },
+    });
+
+    const stream_name = try utils.generateUniqueStreamName(testing.allocator);
+    defer testing.allocator.free(stream_name);
+    const publish_subject = try std.fmt.allocPrint(testing.allocator, "{s}.missing", .{stream_name});
+    defer testing.allocator.free(publish_subject);
+
+    const start = std.Io.Timestamp.now(io, .awake);
+    try testing.expectError(error.Timeout, js.publish(publish_subject, "timeout", .{
+        .retry_wait = .fromSeconds(2),
+        .retry_attempts = 1,
+    }));
+    const elapsed = start.untilNow(io, .awake);
+
+    // The retry wait is clipped to the overall deadline, not added to it.
+    try testing.expect(elapsed.nanoseconds < std.time.ns_per_s);
 }
 
 test "JetStream publish with message deduplication" {


### PR DESCRIPTION
## Summary

- retry synchronous JetStream publishes only after `NoResponders`
- default to two retries with a 250 ms wait, matching `nats.go`
- keep the initial attempt, retry waits, and subsequent attempts under one absolute request deadline
- remove the JetStream metadata-propagation sleep workaround

## Why

During JetStream leadership changes or stream metadata propagation, a publish can receive a transient 503 no-responders response. Returning immediately makes otherwise healthy clustered publishes fail.

`nats.go` retries this specific response; `nats.c` currently performs a single request bounded by `MaxWait`. This implementation follows Go's retry policy while preserving one overall timeout across the complete operation.

## Validation

- `zig build test-unit` — 104/104 passed
- targeted JetStream retry tests — 2/2 passed
- `zig build test`
- `zig build examples`

Closes #131
