### PR TITLE
Check reference count invariants in every optimization mode

### DIFF
--- a/src/ref_counter.zig
+++ b/src/ref_counter.zig
@@ -22,6 +22,16 @@ const std = @import("std");
 ///
 /// This pattern is equivalent to std::shared_ptr in C++ and follows the same
 /// memory ordering guarantees as established in academic literature.
+///
+/// The count invariants are checked with `@panic` rather than
+/// `std.debug.assert`, so they hold in every optimization mode. Violating one
+/// is a memory-safety bug that produces no signal where it happens: an
+/// over-release wraps the count near the integer maximum, so the object is
+/// never destroyed and leaks instead, while a retain racing an in-flight
+/// destroy yields a use-after-free. Both are far cheaper to diagnose as an
+/// immediate crash than as corruption surfacing somewhere else later, and
+/// `ReleaseFast`/`ReleaseSmall` - the modes a client library ships in - are
+/// exactly where that instrumentation matters most.
 pub fn RefCounter(comptime T: type) type {
     return struct {
         refs: std.atomic.Value(T),
@@ -39,7 +49,7 @@ pub fn RefCounter(comptime T: type) type {
         /// from existing ones, which already provide necessary synchronization.
         pub fn incr(self: *Self) void {
             const prev_ref_count = self.refs.fetchAdd(1, .monotonic);
-            std.debug.assert(prev_ref_count > 0);
+            if (prev_ref_count == 0) @panic("reference count resurrected from zero");
         }
 
         /// Decreases the reference count and returns true if it reached zero.
@@ -47,7 +57,7 @@ pub fn RefCounter(comptime T: type) type {
         /// are visible before the count reaches zero.
         pub fn decr(self: *Self) bool {
             const prev_ref_count = self.refs.fetchSub(1, .release);
-            std.debug.assert(prev_ref_count > 0);
+            if (prev_ref_count == 0) @panic("reference count underflow (released too many times)");
             if (prev_ref_count == 1) {
                 // Use acquire load as substitute for fence (Zig 0.14 doesn't have @fence)
                 // This synchronizes with all release operations from other threads


### PR DESCRIPTION
`RefCounter` is the sole mechanism behind `Subscription.retain()`/`release()`, but both of its invariants were guarded with `std.debug.assert` — which `ReleaseFast` and `ReleaseSmall` compile out entirely. Those are the modes a client library actually ships in, so the one piece of instrumentation that would turn a refcount bug into a diagnosable crash was absent exactly where it matters.

Without the check, neither failure mode produces a signal at the point of the mistake:

- an over-release wraps the count near the integer maximum, so the drop-to-zero condition is never met and the object leaks instead of being destroyed;
- a retain racing an in-flight destroy is a use-after-free.

Switched both to `@panic`, which holds in every optimization mode. The cost is a predictable compare on a value `fetchAdd`/`fetchSub` already returns.

### Verification

A standalone harness doing a legitimate release followed by one too many, built in each mode:

| mode | before | after |
|---|---|---|
| Debug | panics | panics |
| ReleaseSafe | panics | panics |
| ReleaseFast | **continues, `count=4294967295`** | panics |
| ReleaseSmall | **continues, `count=4294967295`** | panics |

The full e2e suite passes with the guard live, both in the default mode and under `-Doptimize=ReleaseFast` — no existing path trips it.

### Not included

`connection.zig`'s `notifySubscriptionDrainComplete` has a similarly-patterned Debug-only assert on its drain counter. No path was found that actually drives it negative, and promoting it would change release behavior for a bug that hasn't been demonstrated, so it is left for the cleanup pass rather than bundled here.