### PR TITLE
Take the connection's subscription reference last

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ try nc.publish("hello", "Hello, NATS!");
 // Create synchronous subscription
 var counter: u32 = 0;
 const sub = try nc.subscribeSync("hello");
+defer sub.deinit();
 
 // Wait for message with 5 second timeout
 while (true) {
@@ -105,7 +106,16 @@ fn messageHandler(msg: *nats.Message, counter: *u32) void {
 // Subscribe with callback handler
 var counter: u32 = 0;
 const sub = try nc.subscribe("hello", messageHandler, .{&counter});
+defer sub.deinit();
 ```
+
+Subscriptions are owned by whoever created them, not by the connection: every
+subscription must be released with `sub.deinit()` before its connection is
+destroyed. `deinit()` unsubscribes and, for asynchronous subscriptions, waits
+for the handler task to finish, so it is safe to free anything the handler
+captured once it returns. Destroying a connection that still has live
+subscriptions panics with the number outstanding rather than leaving them
+pointing at freed connection state.
 
 ### Send request and wait for reply
 
@@ -146,6 +156,7 @@ fn echoHandler(msg: *nats.Message, context: *MyContext) !void {
 // Subscribe to handle requests
 var context = MyContext{};
 const sub = try nc.subscribe("echo", echoHandler, .{&context});
+defer sub.deinit();
 ```
 
 ### JetStream Stream Management

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -501,6 +501,11 @@ pub const Connection = struct {
     // Guards `subscriptions`. Acquired after `mutex` when both are held; see
     // the lock-order note on `mutex`.
     subs_mutex: xsync.Mutex = .init,
+    // Every constructed Subscription, whether or not it is still registered in
+    // `subscriptions`. Incremented by Subscription.create, decremented by
+    // Subscription.destroy. Only deinit() reads it, to report subscriptions the
+    // caller never released.
+    live_subscriptions: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
     // Response management (shared subscription for request/reply)
     response_manager: ResponseManager,
@@ -550,12 +555,34 @@ pub const Connection = struct {
         // Clean up response manager
         self.response_manager.deinit();
 
-        // Clean up subscriptions - release connection's references first
-        var iter = self.subscriptions.iterator();
-        while (iter.next()) |entry| {
-            entry.value_ptr.*.release(); // Release connection's ownership reference
+        // Drop the connection's reference to every still-registered
+        // subscription. Detach them under subs_mutex before releasing: an
+        // async subscription's handler task can still be running its own
+        // teardown through unregisterSubscription, and iterating the table
+        // unsynchronized races that on the hashmap's internals.
+        {
+            self.subs_mutex.lockUncancelable(self.io);
+            defer self.subs_mutex.unlock(self.io);
+
+            var iter = self.subscriptions.valueIterator();
+            while (iter.next()) |sub_ptr| {
+                sub_ptr.*.release(); // Release connection's ownership reference
+            }
+            self.subscriptions.clearRetainingCapacity();
         }
         self.subscriptions.deinit();
+
+        // Subscriptions are owned by their creator, not by the connection, so
+        // anything still alive here is a reference the caller never released.
+        // Destroying the connection under it would leave that subscription
+        // pointing at freed connection state, so report it instead of letting
+        // the use-after-free happen later somewhere unrelated.
+        const live = self.live_subscriptions.load(.acquire);
+        if (live != 0) std.debug.panic(
+            "Connection.deinit() with {d} live subscription(s): call sub.deinit() " ++
+                "on every subscription before destroying its connection",
+            .{live},
+        );
 
         // Clean up the buffers
         self.pending_buffer.deinit();
@@ -979,7 +1006,14 @@ pub const Connection = struct {
         }
     }
 
-    fn subscribeInternal(self: *Self, sub: *Subscription) !void {
+    /// Register a freshly created subscription with the connection and tell the
+    /// server about it.
+    ///
+    /// The connection's reference is taken last, once every fallible step has
+    /// succeeded. Any failure therefore leaves the subscription at the single
+    /// reference its creator holds, so the caller's `errdefer sub.release()`
+    /// destroys it - no unwind bookkeeping is needed at the call sites.
+    fn registerSubscription(self: *Self, sub: *Subscription) !void {
         try self.mutex.lock(self.io);
         defer self.mutex.unlock(self.io);
 
@@ -1005,19 +1039,39 @@ pub const Connection = struct {
             try buffer.writer.print("SUB {s} {d}\r\n", .{ sub.subject, sub.sid });
         }
         try self.write_buffer.appendUnmetered(buffer.written());
+
+        // Past the last failure point: the table now owns a reference.
+        sub.retain();
+    }
+
+    /// Undo registerSubscription. Safe to call when the subscription was
+    /// already removed - the connection's reference is dropped at most once.
+    fn unregisterSubscription(self: *Self, sub: *Subscription) void {
+        {
+            self.subs_mutex.lockUncancelable(self.io);
+            defer self.subs_mutex.unlock(self.io);
+
+            if (!self.subscriptions.remove(sub.sid)) return;
+        }
+
+        sub.release();
     }
 
     pub fn subscribe(self: *Self, subject: []const u8, comptime handlerFn: anytype, args: anytype) !*Subscription {
         try validation.validateSubject(subject);
 
+        // Subscription.create takes ownership of the handler on every path,
+        // so registering cleanup for it here would free it twice.
         const handler = try subscription_mod.createMsgHandler(self.allocator, handlerFn, args);
-        errdefer handler.cleanup(self.allocator);
 
         const sid = self.next_sid.fetchAdd(1, .monotonic);
         const sub = try Subscription.create(self, sid, subject, null, handler);
         errdefer sub.release();
 
-        try self.subscribeInternal(sub);
+        try self.registerSubscription(sub);
+        // A registered subscription whose handler never starts would keep
+        // accumulating messages that nobody can consume or unsubscribe.
+        errdefer self.unregisterSubscription(sub);
         try sub.startHandler();
 
         log.debug("Subscribed to {s} with sid {d} (async)", .{ sub.subject, sub.sid });
@@ -1032,7 +1086,7 @@ pub const Connection = struct {
         const sub = try Subscription.create(self, sid, subject, null, null);
         errdefer sub.release();
 
-        try self.subscribeInternal(sub);
+        try self.registerSubscription(sub);
 
         log.debug("Subscribed to {s} with sid {d} (sync)", .{ sub.subject, sub.sid });
         return sub;
@@ -1042,14 +1096,18 @@ pub const Connection = struct {
         try validation.validateSubject(subject);
         try validation.validateQueueName(queue);
 
+        // Subscription.create takes ownership of the handler on every path,
+        // so registering cleanup for it here would free it twice.
         const handler = try subscription_mod.createMsgHandler(self.allocator, handlerFn, args);
-        errdefer handler.cleanup(self.allocator);
 
         const sid = self.next_sid.fetchAdd(1, .monotonic);
         const sub = try Subscription.create(self, sid, subject, queue, handler);
         errdefer sub.release();
 
-        try self.subscribeInternal(sub);
+        try self.registerSubscription(sub);
+        // A registered subscription whose handler never starts would keep
+        // accumulating messages that nobody can consume or unsubscribe.
+        errdefer self.unregisterSubscription(sub);
         try sub.startHandler();
 
         log.debug("Subscribed to {s} with queue group '{s}' and sid {d} (async)", .{ sub.subject, queue, sub.sid });
@@ -1065,7 +1123,7 @@ pub const Connection = struct {
         const sub = try Subscription.create(self, sid, subject, queue, null);
         errdefer sub.release();
 
-        try self.subscribeInternal(sub);
+        try self.registerSubscription(sub);
 
         log.debug("Subscribed to {s} with queue group '{s}' and sid {d} (sync)", .{ sub.subject, queue, sub.sid });
         return sub;
@@ -1096,7 +1154,8 @@ pub const Connection = struct {
     }
 
     pub fn unsubscribe(self: *Self, sub: *Subscription) void {
-        // Remove from subscription table first
+        // Detach from the table first. If it was already detached there is
+        // nothing to send and no reference left to drop.
         {
             self.mutex.lockUncancelable(self.io);
             defer self.mutex.unlock(self.io);
@@ -1133,15 +1192,22 @@ pub const Connection = struct {
     /// Remove subscription from connection's subscription table
     /// This does not send UNSUB to server - that should be done separately
     pub fn removeSubscriptionInternal(self: *Self, sid: u64) void {
-        self.subs_mutex.lockUncancelable(self.io);
-        defer self.subs_mutex.unlock(self.io);
+        // Detach under the lock, act outside it - the same shape as
+        // unregisterSubscription. Releasing the last reference destroys the
+        // subscription, which joins its handler task; that task can itself be
+        // waiting on subs_mutex, so the release must not run under it.
+        const sub = blk: {
+            self.subs_mutex.lockUncancelable(self.io);
+            defer self.subs_mutex.unlock(self.io);
 
-        if (self.subscriptions.fetchRemove(sid)) |kv| {
-            log.debug("Removed subscription {d} ({s}) from connection", .{ sid, kv.value.subject });
-            kv.value.closeFromConnection();
-            // Release connection's reference to the subscription
-            kv.value.release();
-        }
+            const entry = self.subscriptions.fetchRemove(sid) orelse return;
+            break :blk entry.value;
+        };
+
+        log.debug("Removed subscription {d} ({s}) from connection", .{ sid, sub.subject });
+        sub.closeFromConnection();
+        // Release connection's reference to the subscription
+        sub.release();
     }
 
     pub fn flush(self: *Self) !void {
@@ -2633,7 +2699,7 @@ pub const Connection = struct {
         // after unlocking. Subscription.drain() sends UNSUB through
         // unsubscribeInternal, which takes the connection mutex, so draining
         // while holding subs_mutex would acquire the two in the opposite
-        // order from subscribeInternal - an AB-BA deadlock against any
+        // order from registerSubscription - an AB-BA deadlock against any
         // concurrent subscribe().
         var draining = ArrayList(*Subscription).empty;
         defer {

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -88,7 +88,13 @@ pub const Subscription = struct {
     pub const default_pending_msgs_limit: u32 = 500_000;
     pub const default_pending_bytes_limit: u64 = 64 * 1024 * 1024;
 
+    /// Create a subscription. Takes ownership of `handler` on both success and
+    /// failure: on success `destroy` cleans it up, on failure this function
+    /// does. Callers must not register their own cleanup for it, or it would
+    /// be freed twice.
     pub fn create(nc: *Connection, sid: u64, subject: []const u8, queue_group: ?[]const u8, handler: ?MsgHandler) !*Subscription {
+        errdefer if (handler) |h| h.cleanup(nc.allocator);
+
         const sub = try nc.allocator.create(Subscription);
         errdefer nc.allocator.destroy(sub);
 
@@ -107,11 +113,12 @@ pub const Subscription = struct {
             .handler = handler,
         };
 
-        // Subscription starts with 1 reference (from RefCounter.init())
-        // Add an additional reference for the user - total will be 2 refs:
-        // 1. Connection reference (for hashmap storage)
-        // 2. User reference (for returned pointer)
-        sub.retain();
+        // Starts with the single reference from RefCounter.init(), owned by
+        // the caller. The connection takes its own reference only once
+        // registerSubscription has fully succeeded, so every failure between
+        // here and there unwinds through the caller's `errdefer sub.release()`
+        // and destroys the subscription.
+        _ = nc.live_subscriptions.fetchAdd(1, .monotonic);
 
         return sub;
     }
@@ -216,7 +223,9 @@ pub const Subscription = struct {
         }
         self.messages.deinit();
 
-        self.nc.allocator.destroy(self);
+        const nc = self.nc;
+        nc.allocator.destroy(self);
+        _ = nc.live_subscriptions.fetchSub(1, .release);
     }
 
     /// Wake subscription receivers and drain waiters when their owning

--- a/tests/all_tests.zig
+++ b/tests/all_tests.zig
@@ -20,6 +20,7 @@ test {
     _ = @import("reconnect_limits_test.zig");
     _ = @import("keepalive_test.zig");
     _ = @import("callbacks_test.zig");
+    _ = @import("drain_race_test.zig");
     _ = @import("jetstream_test.zig");
     _ = @import("jetstream_stream_test.zig");
     _ = @import("jetstream_push_test.zig");

--- a/tests/drain_race_test.zig
+++ b/tests/drain_race_test.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const nats = @import("nats");
+const utils = @import("utils.zig");
+
+const Subscriber = struct {
+    conn: *nats.Connection,
+    stop: std.atomic.Value(bool) = .init(false),
+    ok: std.atomic.Value(u32) = .init(0),
+    failed: std.atomic.Value(u32) = .init(0),
+
+    /// Subscribe in a tight loop so that at any given moment this task is
+    /// likely to be inside subscribeInternal, holding the connection mutex
+    /// and waiting on subs_mutex. That is the half of the AB-BA pair that
+    /// drain() used to complete by taking the two in the opposite order.
+    fn run(self: *Subscriber) void {
+        var buf: [64]u8 = undefined;
+        var i: u32 = 0;
+        while (!self.stop.load(.acquire)) : (i += 1) {
+            const subject = std.fmt.bufPrint(&buf, "drain.race.{d}", .{i}) catch return;
+            const sub = self.conn.subscribeSync(subject) catch {
+                _ = self.failed.fetchAdd(1, .monotonic);
+                return;
+            };
+            _ = self.ok.fetchAdd(1, .monotonic);
+            sub.deinit();
+        }
+    }
+};
+
+// Regression test for the drain()/subscribe() lock-order inversion.
+//
+// drain() used to hold subs_mutex across Subscription.drain(), which sends
+// UNSUB via unsubscribeInternal and therefore takes the connection mutex -
+// the reverse of subscribeInternal's mutex-then-subs_mutex order. A drain
+// racing a subscribe deadlocked both tasks permanently, wedging the
+// connection including its own shutdown path.
+//
+// Note the failure mode: a regression here hangs rather than fails, and is
+// caught by the CI job timeout rather than by an assertion.
+test "connection drain concurrent with subscribe does not deadlock" {
+    const io = std.testing.io;
+
+    for (0..10) |_| {
+        const conn = try utils.createDefaultConnection(io);
+        defer utils.closeConnection(conn);
+
+        // Seed subscriptions so drain() has real work to do in the window
+        // where it used to hold subs_mutex.
+        var seeded: [32]*nats.Subscription = undefined;
+        for (&seeded, 0..) |*slot, k| {
+            var buf: [64]u8 = undefined;
+            const subject = try std.fmt.bufPrint(&buf, "drain.race.seed.{d}", .{k});
+            slot.* = try conn.subscribeSync(subject);
+        }
+        defer for (seeded) |sub| sub.deinit();
+
+        var subscriber = Subscriber{ .conn = conn };
+        var group: std.Io.Group = .init;
+        try group.concurrent(io, Subscriber.run, .{&subscriber});
+        // Stop the subscriber by flag and join it, rather than cancelling:
+        // cancelling mid-subscribe makes subscribeInternal fail, and the
+        // subscribe entry points currently leak the subscription on that
+        // path (they release only one of its two references).
+        defer {
+            subscriber.stop.store(true, .release);
+            group.await(io) catch {};
+        }
+
+        // Give the subscriber time to reach the contended window.
+        try io.sleep(.fromMilliseconds(2), .awake);
+
+        try conn.drain();
+        conn.waitForDrainCompletion(.{ .duration = .{ .raw = .fromSeconds(2), .clock = .awake } }) catch {};
+    }
+}

--- a/tests/subscribe_test.zig
+++ b/tests/subscribe_test.zig
@@ -161,3 +161,36 @@ test "queueSubscribe smoke test" {
     try std.testing.expectEqualStrings("test", msg.subject);
     try std.testing.expectEqualStrings("Hello world!", msg.data);
 }
+
+// A subscription is created before it is registered with the connection, so
+// every registration failure has to unwind it completely. Registration used to
+// leave it at one of its two references, leaking the subscription, its subject
+// copy and - for the async variants - its handler context. Closing the
+// connection first makes registerSubscription fail deterministically; the
+// testing allocator reports any reference that was not unwound.
+test "subscribing on a closed connection unwinds completely" {
+    var conn = try utils.createDefaultConnection(std.testing.io);
+    defer utils.closeConnection(conn);
+
+    conn.close();
+
+    try std.testing.expectError(error.ConnectionClosed, conn.subscribeSync("test.unwind"));
+    try std.testing.expectError(error.ConnectionClosed, conn.queueSubscribeSync("test.unwind", "workers"));
+}
+
+// Same unwind, but through the async entry points: these also allocate a
+// handler context. Subscription.create takes ownership of it, so the entry
+// point must not clean it up as well - once the refcount unwind actually
+// destroys the subscription, doing both would free the context twice.
+test "subscribing with a handler on a closed connection unwinds completely" {
+    var conn = try utils.createDefaultConnection(std.testing.io);
+    defer utils.closeConnection(conn);
+
+    var collector: MessageCollector = .{};
+    defer collector.deinit();
+
+    conn.close();
+
+    try std.testing.expectError(error.ConnectionClosed, conn.subscribe("test.unwind", MessageCollector.processMsg, .{&collector}));
+    try std.testing.expectError(error.ConnectionClosed, conn.queueSubscribe("test.unwind", "workers", MessageCollector.processMsg, .{&collector}));
+}


### PR DESCRIPTION
> **Stacked on #153** — the first commit here is that PR's. Review the second commit, or merge #153 first.

A subscription was created with two references already charged — one for the caller, one for the connection's table — before it had been registered with anything. Every failure between creation and successful registration therefore had to hand back two references, but all four `subscribe*` entry points guard it with a single `errdefer sub.release()`, which only took the count 2→1 and never destroyed. `registerSubscription`'s own error path compounded it by removing the table entry without releasing what that entry held.

The result: a permanently leaked subscription on any failed subscribe. Not exotic — it fires whenever a caller races a subscribe against a reconnect or a closing connection.

### The fix

Create the subscription with the single reference its creator owns, and have `registerSubscription` take the connection's reference **last**, after the table insert and the SUB frame have both succeeded:

```zig
try self.subscriptions.put(sub.sid, sub);
errdefer _ = self.subscriptions.remove(sub.sid);
// ... build + append the SUB frame ...

// Past the last failure point: the table now owns a reference.
sub.retain();
```

Any failure now leaves exactly one reference and the existing `errdefer` destroys it. No unwind bookkeeping at the call sites, and no per-site patching.

### Three things fall out of making the unwind real

**`Subscription.create` now owns the handler on every path.** The entry points used to clean it up themselves, which was harmless *only* because the subscription was never actually destroyed. With the unwind fixed, `destroy()` and the entry point would both free the handler context. Reintroducing the old `errdefer` on top of this branch produces an invalid free, so the two changes genuinely have to travel together.

**`startHandler` failures unregister.** A subscription that registered but whose handler task never started wasn't leaked, but it was invisible: the server kept delivering into a queue with no consumer, and the caller never got the pointer needed to unsubscribe it.

**`deinit()` detaches under `subs_mutex` before releasing**, instead of iterating the table unsynchronized while an async subscription's handler task may be mutating it through its own teardown. `removeSubscriptionInternal` is reshaped to the same detach-then-act pattern, so a release that may destroy a subscription — and therefore join its handler task — never runs under the lock that task might be waiting on.

### Ownership contract

Subscriptions are owned by their creator, not by the connection. A connection destroyed while any remain alive would leave them pointing at freed state, so `deinit()` now counts live subscriptions and panics with the number outstanding.

This deliberately counts **object lifetime, not table membership**: a subscription that left the table through autounsubscribe is exactly the one that would use-after-free on a late `deinit()`, and it wouldn't be in the table to be found.

The contract is documented in the README, and the three core examples that didn't release their subscriptions now do.

### Verification

- Full `./check.sh`: **179/179**, and the e2e suite also passes under `-Doptimize=ReleaseFast`, where #152's refcount panic is live.
- Two new deterministic tests subscribe on a closed connection through all four entry points; the testing allocator reports any reference left unwound. Reverting the create-at-1 change makes them fail immediately — with the new panic, `Connection.deinit() with 2 live subscription(s)`.
- The drain/subscribe race test held back from #153 lands here. It leaked roughly 1 run in 5 before; now 8 consecutive runs are clean.