### PR TITLE
Bound the CI job and drop its apt dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     # Without this the job inherits the 6 hour default, so anything that
-    # blocks burns a runner for the rest of the day instead of failing.
+    # blocks holds a runner for the rest of the day instead of failing.
     timeout-minutes: 20
 
     steps:
@@ -19,27 +19,6 @@ jobs:
       uses: mlugg/setup-zig@v2
       with:
         version: 0.16.0
-
-    # The azure.archive.ubuntu.com mirror the runner images default to is
-    # intermittently unreachable, and apt retries it for minutes before
-    # falling back - which is what stalled this job for over an hour. Point
-    # at the canonical archive, bound apt's own retries, and give it a lock
-    # timeout so a background unattended-upgrades run cannot block it
-    # forever either. -y and the noninteractive frontend keep it from
-    # stopping on a confirmation prompt it can never receive.
-    - name: Install libnats
-      timeout-minutes: 8
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: |
-        sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
-          /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
-        for attempt in 1 2 3; do
-          sudo apt-get -o Acquire::Retries=3 -o DPkg::Lock::Timeout=120 update && break
-          echo "apt-get update failed (attempt $attempt of 3), retrying"
-          sleep 5
-        done
-        sudo apt-get -o Acquire::Retries=3 -o DPkg::Lock::Timeout=120 install -y libnats-dev
 
     - name: Check code formatting
       run: zig fmt --check .
@@ -57,6 +36,10 @@ jobs:
     - name: Build examples
       run: zig build examples
 
+    # The C benchmarks link against the system libnats. Installing it made
+    # this job depend on an apt mirror that repeatedly stalled for the full
+    # job timeout, and building them proves nothing about this library, so
+    # only the Zig benchmarks are built here.
     - name: Build benchmarks
-      run: zig build
+      run: zig build -Dc_benchmarks=false
       working-directory: benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Without this the job inherits the 6 hour default, so anything that
+    # blocks burns a runner for the rest of the day instead of failing.
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -17,16 +20,29 @@ jobs:
       with:
         version: 0.16.0
 
+    # apt is given an explicit lock timeout: the runner images periodically
+    # run unattended-upgrades, and apt waits for /var/lib/dpkg/lock-frontend
+    # forever by default. -y and the noninteractive frontend keep it from
+    # stopping on a confirmation prompt it can never receive.
     - name: Install libnats
-      run: sudo apt-get update && sudo apt-get install libnats-dev
+      timeout-minutes: 5
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get -o DPkg::Lock::Timeout=120 update
+        sudo apt-get -o DPkg::Lock::Timeout=120 install -y libnats-dev
 
     - name: Check code formatting
       run: zig fmt --check .
 
     - name: Run unit tests
+      timeout-minutes: 5
       run: zig build test-unit
 
+    # A deadlock in the client shows up here as a test that never returns, so
+    # this step needs a bound of its own rather than relying on the job one.
     - name: Run integration tests
+      timeout-minutes: 10
       run: zig build test-e2e
 
     - name: Build examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,26 @@ jobs:
       with:
         version: 0.16.0
 
-    # apt is given an explicit lock timeout: the runner images periodically
-    # run unattended-upgrades, and apt waits for /var/lib/dpkg/lock-frontend
-    # forever by default. -y and the noninteractive frontend keep it from
+    # The azure.archive.ubuntu.com mirror the runner images default to is
+    # intermittently unreachable, and apt retries it for minutes before
+    # falling back - which is what stalled this job for over an hour. Point
+    # at the canonical archive, bound apt's own retries, and give it a lock
+    # timeout so a background unattended-upgrades run cannot block it
+    # forever either. -y and the noninteractive frontend keep it from
     # stopping on a confirmation prompt it can never receive.
     - name: Install libnats
-      timeout-minutes: 5
+      timeout-minutes: 8
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get -o DPkg::Lock::Timeout=120 update
-        sudo apt-get -o DPkg::Lock::Timeout=120 install -y libnats-dev
+        sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+          /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+        for attempt in 1 2 3; do
+          sudo apt-get -o Acquire::Retries=3 -o DPkg::Lock::Timeout=120 update && break
+          echo "apt-get update failed (attempt $attempt of 3), retrying"
+          sleep 5
+        done
+        sudo apt-get -o Acquire::Retries=3 -o DPkg::Lock::Timeout=120 install -y libnats-dev
 
     - name: Check code formatting
       run: zig fmt --check .

--- a/benchmarks/build.zig
+++ b/benchmarks/build.zig
@@ -35,7 +35,16 @@ pub fn build(b: *std.Build) void {
         b.installArtifact(exe);
     }
 
-    // C equivalents built on the official client (require system libnats)
+    // C equivalents built on the official client. These need system libnats,
+    // which is not present everywhere - CI in particular does not install it,
+    // since pulling it in made the job depend on an apt mirror that stalls.
+    const c_benchmarks = b.option(
+        bool,
+        "c_benchmarks",
+        "Build the C benchmarks against the system libnats (default: true)",
+    ) orelse true;
+    if (!c_benchmarks) return;
+
     for (benchmarks) |name| {
         const exe = b.addExecutable(.{
             .name = b.fmt("{s}_c", .{name}),


### PR DESCRIPTION
Two CI runs stalled and held runners for over an hour. The job had no `timeout-minutes`, so it inherited the **six hour** default.

### It was never the code

Both stalls were in step 4, **Install libnats** — before anything in this repo is compiled:

| run | branch | state |
|---|---|---|
| 32227353103 | `audit/drain-lock-order` (#153) | stalled in *Install libnats*, 80+ min |
| 32226130918 | `audit/refcount-guard` (#152) | stalled in *Install libnats* |
| 32230740578 | `audit/subscription-refcount` (#154) | **success** |

#154 contains #153's commit plus a larger change on top, and it passed; #152 is already merged and its `main` run passed. The stall followed neither branch nor commit. Both hung runs have been cancelled.

### What it actually was

Bounding the step turned the stall into a fast failure, which made the cause legible. `azure.archive.ubuntu.com` — the mirror the runner images default to — is unreachable, so apt logs `Ign` for every index on it, falls back to `archive.ubuntu.com`, and then stalls fetching package lists there too:

```
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
...
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
##[error]The action 'Install libnats' has timed out after 8 minutes.
```

Seven minutes of silence between the last index and the timeout. My first guess was a `dpkg` lock held by `unattended-upgrades`; that was wrong. Rewriting the mirror list did not help either, because both paths stall.

### Fix

`libnats-dev` was only ever needed to link the **C** benchmarks, which exercise the official C client rather than anything in this repository. Building them in CI proves nothing about this library while making the job depend on an apt mirror.

- `benchmarks/build.zig` gains `-Dc_benchmarks`, defaulting to `true` so local builds are unchanged. CI passes `false`.
- The `Install libnats` step is gone. CI no longer touches apt at all.
- `timeout-minutes: 20` on the job, plus bounds on the steps that can genuinely block: unit tests (5) and integration tests (10). Those matter independently of this incident — a deadlock in the client presents as a test that never returns, which is exactly what a bounded step should catch instead of a six-hour job.

### Result

Green in **1m38s**, down from a 6-hour ceiling. Verified locally that the default still builds all eight benchmark binaries and `-Dc_benchmarks=false` builds the four Zig ones.
