### PR TITLE
Release detached subscriptions outside subs_mutex in deinit

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -560,17 +560,33 @@ pub const Connection = struct {
         // async subscription's handler task can still be running its own
         // teardown through unregisterSubscription, and iterating the table
         // unsynchronized races that on the hashmap's internals.
+        //
+        // The release itself happens after unlocking, as in
+        // removeSubscriptionInternal: releasing the last reference destroys
+        // the subscription, which joins its handler task, and that task can
+        // be waiting on subs_mutex.
+        var detached = ArrayList(*Subscription).empty;
+        defer detached.deinit(self.allocator);
         {
             self.subs_mutex.lockUncancelable(self.io);
             defer self.subs_mutex.unlock(self.io);
 
+            detached.ensureTotalCapacity(self.allocator, self.subscriptions.count()) catch {};
+
             var iter = self.subscriptions.valueIterator();
             while (iter.next()) |sub_ptr| {
-                sub_ptr.*.release(); // Release connection's ownership reference
+                // Falling back to releasing under the lock is still better
+                // than leaking the reference outright; an allocation failure
+                // here means the process is already out of memory.
+                detached.append(self.allocator, sub_ptr.*) catch sub_ptr.*.release();
             }
             self.subscriptions.clearRetainingCapacity();
         }
         self.subscriptions.deinit();
+
+        for (detached.items) |sub| {
+            sub.release(); // Release connection's ownership reference
+        }
 
         // Subscriptions are owned by their creator, not by the connection, so
         // anything still alive here is a reference the caller never released.

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -582,11 +582,19 @@ pub const Connection = struct {
             }
             self.subscriptions.clearRetainingCapacity();
         }
-        self.subscriptions.deinit();
 
         for (detached.items) |sub| {
             sub.release(); // Release connection's ownership reference
         }
+
+        // Only now free the table's storage. A handler task that was blocked
+        // on subs_mutex during the loop above acquires it as soon as this
+        // function unlocks and calls remove() on the table - harmless while
+        // the table is merely empty, a use-after-free once its memory is
+        // gone. Releasing first is what closes that window: the release that
+        // destroys a subscription joins its handler task, so by this point
+        // those tasks are done with the table.
+        self.subscriptions.deinit();
 
         // Subscriptions are owned by their creator, not by the connection, so
         // anything still alive here is a reference the caller never released.

--- a/tests/drain_race_test.zig
+++ b/tests/drain_race_test.zig
@@ -58,9 +58,8 @@ test "connection drain concurrent with subscribe does not deadlock" {
         var group: std.Io.Group = .init;
         try group.concurrent(io, Subscriber.run, .{&subscriber});
         // Stop the subscriber by flag and join it, rather than cancelling:
-        // cancelling mid-subscribe makes subscribeInternal fail, and the
-        // subscribe entry points currently leak the subscription on that
-        // path (they release only one of its two references).
+        // cancelling mid-subscribe makes registerSubscription fail, and this
+        // test is about the lock order, not about the unwind.
         defer {
             subscriber.stop.store(true, .release);
             group.await(io) catch {};
@@ -70,6 +69,10 @@ test "connection drain concurrent with subscribe does not deadlock" {
         try io.sleep(.fromMilliseconds(2), .awake);
 
         try conn.drain();
-        conn.waitForDrainCompletion(.{ .duration = .{ .raw = .fromSeconds(2), .clock = .awake } }) catch {};
+        // Assert completion rather than swallowing it: the drain has to finish,
+        // not merely avoid deadlocking. A subscription drain that never reports
+        // completion leaves drain_subscription_count above zero and parks this
+        // call until it times out, which a discarded result would hide.
+        try conn.waitForDrainCompletion(.{ .duration = .{ .raw = .fromSeconds(5), .clock = .awake } });
     }
 }


### PR DESCRIPTION
Follow-up to a review of #153/#154. One of the two findings held up; the other did not.

## Applied: release outside `subs_mutex`

`deinit()` released the connection's reference to each subscription while still holding `subs_mutex`. Releasing the last reference destroys the subscription, and `destroy()` joins its handler task — which can itself be waiting on `subs_mutex`. That is exactly the deadlock `removeSubscriptionInternal` is shaped to avoid, one function away.

No supported call sequence reaches it today: a subscription still in the table always has its creator's reference as well, because `Subscription.deinit()` detaches before releasing. But the invariant shouldn't rest on that, and the inconsistency is the kind that gets copied.

Collect under the lock, release after unlocking. On allocation failure it falls back to releasing under the lock — still better than dropping the reference.

## Applied: free the table after releasing, not before

A second review pass caught an ordering bug in the fix above. `subscriptions.deinit()` ran immediately after the table was cleared, before the release loop — so the table's storage was freed while a handler task could still be blocked on `subs_mutex`. That task acquires the lock as soon as the loop unlocks and calls `remove()`: harmless against a merely empty table, a use-after-free once its memory is gone.

Releasing first is what closes the window, because the release that destroys a subscription joins its handler task. By the time the storage is freed, those tasks are done with the table. Moved `subscriptions.deinit()` below the loop.

## Not applied: skipping the drain count for already-drained subscriptions

The review asked that `Connection.drain` not add a `drain_subscription_count` entry for a subscription whose drain already completed. **That case is already balanced, and the change would unbalance it.**

`Subscription.drain()` increments and decrements its own pending counter around the `draining` compare-exchange. On the already-draining path the compare-exchange fails and it returns early, but the deferred `decrementPending` still runs — and that is what fires the completion notification. So the count added by the snapshot is matched.

Instrumented, draining a connection over one already-drained subscription:

```
current code                          with the review's change
[snapshot done] count=2 subs=1        [snapshot done] count=1 subs=1
[notify] state=draining_subs count=2  [notify] state=draining_subs count=1
[notify] state=draining_subs count=1  [notify] state=draining_pubs count=0
```

Current: the count reaches zero exactly when the blocker is released, and publication drain begins there.

With the change: the subscription's own notification takes the count to zero **while the blocker is still held**, so publication drain starts early — the blocker exists precisely to prevent that — and the blocker's own decrement then lands on `state=draining_pubs` and is discarded by the state guard.

Both versions pass their tests, because that state guard absorbs the discrepancy. That masking is the only reason the change looks harmless.

The counting is structurally loose — increments are unconditional while decrements are gated on `drain_state`, and the completion notification is not idempotent. I could not drive it to an observable failure from either direction (probes for the already-drained case and for an application drain racing the connection drain both pass), so I have left it alone rather than restructure it on speculation. Worth its own change if a failure ever materialises.

## Applied: the test assertion

The third note was fair. `tests/drain_race_test.zig` discarded the result of `waitForDrainCompletion`, so a drain that never completed would have passed silently — it only ever asserted the absence of a deadlock. It now asserts completion (5/5 runs pass), and a comment left stale by #154's rename is corrected.

## Verification

`./check.sh` 179/179, and `-Doptimize=ReleaseFast` e2e 179/179.
