### PR TITLE
Type-check the public surface, fixing three functions that never compiled

### DIFF
--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -1671,7 +1671,7 @@ pub const JetStream = struct {
     }
 
     /// Open an existing KV bucket
-    pub fn kvBucket(self: JetStream, bucket_name: []const u8) !*@import("jetstream_kv.zig").KV {
+    pub fn kvBucket(self: JetStream, bucket_name: []const u8) !@import("jetstream_kv.zig").KV {
         var manager = self.kvManager();
         return try manager.openBucket(bucket_name);
     }

--- a/src/jetstream_kv.zig
+++ b/src/jetstream_kv.zig
@@ -547,7 +547,7 @@ pub const KV = struct {
             for (subjects.items) |subject| {
                 self.js.nc.allocator.free(subject);
             }
-            subjects.deinit();
+            subjects.deinit(self.js.nc.allocator);
         }
 
         for (key_patterns) |key| {

--- a/src/root.zig
+++ b/src/root.zig
@@ -106,3 +106,30 @@ test {
     _ = @import("jetstream_kv.zig");
     _ = @import("jetstream_objstore.zig");
 }
+
+/// Reference every public declaration of `T`, and of every public type it
+/// exposes, so the semantic analyzer walks their bodies.
+///
+/// `std.testing.refAllDecls` only covers one level, which is not enough here:
+/// the interesting declarations are methods on re-exported types rather than
+/// on this module.
+fn refAllDeclsRecursive(comptime T: type) void {
+    inline for (comptime std.meta.declarations(T)) |decl| {
+        if (@TypeOf(@field(T, decl.name)) == type) {
+            switch (@typeInfo(@field(T, decl.name))) {
+                .@"struct", .@"enum", .@"union", .@"opaque" => refAllDeclsRecursive(@field(T, decl.name)),
+                else => {},
+            }
+        }
+        _ = &@field(T, decl.name);
+    }
+}
+
+// Zig only analyses a `pub fn` once something references it, so a public
+// function nothing calls can carry a type error indefinitely. kvBucket did
+// exactly that: it never compiled, and nothing in the tree called it, so
+// only a downstream user would ever have found out. Referencing the public
+// surface here makes the compiler check it as part of the unit test build.
+test "public declarations type-check" {
+    refAllDeclsRecursive(@This());
+}

--- a/src/server_pool.zig
+++ b/src/server_pool.zig
@@ -66,7 +66,6 @@ pub const Server = struct {
 // Server pool matching C library's natsSrvPool
 pub const ServerPool = struct {
     servers: StringArrayHashMapUnmanaged(*Server), // Combined hash map with insertion order (host:port -> *Server)
-    randomize: bool = false, // Whether to randomize order
     default_user: ?[]const u8 = null, // Default username from first explicit URL
     default_pwd: ?[]const u8 = null, // Default password from first explicit URL
     allocator: Allocator,
@@ -169,29 +168,6 @@ pub const ServerPool = struct {
     pub fn getFirstServer(self: *ServerPool) ?*Server {
         const values = self.servers.values();
         return if (values.len > 0) values[0] else null;
-    }
-
-    // Shuffle servers in pool (like C library's _shufflePool)
-    pub fn shuffle(self: *ServerPool, io: std.Io, offset: usize) std.mem.Allocator.Error!void {
-        if (self.servers.count() <= offset + 1) return;
-
-        var seed: u64 = undefined;
-        io.random(std.mem.asBytes(&seed));
-        var prng = std.Random.DefaultPrng.init(seed);
-        const random = prng.random();
-
-        // Shuffle the underlying entries directly
-        var i = offset;
-        while (i < self.servers.entries.len) : (i += 1) {
-            const j = offset + random.uintLessThan(usize, i + 1 - offset);
-            const entry_i = self.servers.entries.get(i);
-            self.servers.entries.set(i, self.servers.entries.get(j));
-            self.servers.entries.set(j, entry_i);
-        }
-
-        // Rebuild the hash index. A failure here leaves the entries shuffled
-        // but the index stale, so it has to propagate rather than be ignored.
-        try self.servers.reIndex(self.allocator);
     }
 };
 

--- a/src/server_pool.zig
+++ b/src/server_pool.zig
@@ -172,7 +172,7 @@ pub const ServerPool = struct {
     }
 
     // Shuffle servers in pool (like C library's _shufflePool)
-    pub fn shuffle(self: *ServerPool, io: std.Io, offset: usize) void {
+    pub fn shuffle(self: *ServerPool, io: std.Io, offset: usize) std.mem.Allocator.Error!void {
         if (self.servers.count() <= offset + 1) return;
 
         var seed: u64 = undefined;
@@ -184,11 +184,14 @@ pub const ServerPool = struct {
         var i = offset;
         while (i < self.servers.entries.len) : (i += 1) {
             const j = offset + random.uintLessThan(usize, i + 1 - offset);
-            self.servers.entries.swap(i, j);
+            const entry_i = self.servers.entries.get(i);
+            self.servers.entries.set(i, self.servers.entries.get(j));
+            self.servers.entries.set(j, entry_i);
         }
 
-        // Rebuild the hash index
-        self.servers.reIndex(self.allocator);
+        // Rebuild the hash index. A failure here leaves the entries shuffled
+        // but the index stale, so it has to propagate rather than be ignored.
+        try self.servers.reIndex(self.allocator);
     }
 };
 


### PR DESCRIPTION
`JetStream.kvBucket` was declared to return `!*KV` while `KVManager.openBucket`, which it delegates to, returns `!KV`. The function could not compile.

It built anyway because nothing in `src/`, `tests/` or `examples/` calls it, and Zig only analyses a `pub fn` once something references it. Only a downstream user calling this documented convenience method would have found out — via a compile error pointing into library internals rather than their own code.

`KV` is used as a value everywhere else (`var kv = try kv_manager.createBucket(...)`), so the return type is what was wrong, not the callee.

### The guard matters more than the fix

A one-line fix leaves the underlying problem intact: any other uncalled `pub fn` can carry a type error indefinitely. So this adds a unit test that references the public surface recursively.

`std.testing.refAllDecls` only covers one level, which is not enough here — the interesting declarations are methods on re-exported types, not on the root module — so the test walks into public types itself.

### It immediately found two more

Both uncalled, both broken against the current standard library, neither flagged by any audit:

**`KV.watchMulti`** (`jetstream_kv.zig`) called `subjects.deinit()` with no allocator, which the unmanaged `ArrayList` requires.

**`ServerPool.shuffle`** (`server_pool.zig`) called `swap` on a `MultiArrayList`, which no longer has one — **deleted, along with the `randomize` flag it existed to serve.**

It has never had a caller, and `randomize` is written in the struct definition and read nowhere; both date from the original reconnection commit, and pool randomisation was never wired up. Repairing it meant inventing a signature and an index-rebuild strategy for a feature that does not exist — and getting it wrong, since `reIndex` allocates a fresh index header where a reorder needs no allocation at all (`sortUnstable` does the same reorder-and-reindex for free by reusing the existing header). Removing both is cheaper than maintaining either. If pool randomisation is wanted later it should be designed against `getNextServer`'s selection logic, not restored from this.

### Verification

Reverting the `kvBucket` signature now fails the build with the original error, so the guard demonstrably catches this class of rot. `./check.sh`: 179/179, unit tests 132/132.

### Scope note

`kvBucket` and `watchMulti` are user-facing API — meant to be called from outside the repo, just never called inside it — so they are fixed. `shuffle` is neither called nor reachable through any implemented feature, so it is deleted. Broken and unused are not the same as broken and needed.
