### PR TITLE
Bound inbound control lines and message sizes

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -15,7 +15,8 @@ const std = @import("std");
 const net = std.Io.net;
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
-const Parser = @import("parser.zig").Parser;
+const parser_mod = @import("parser.zig");
+const Parser = parser_mod.Parser;
 const inbox = @import("inbox.zig");
 const Message = @import("message.zig").Message;
 const MessageList = @import("message.zig").MessageList;
@@ -376,6 +377,16 @@ pub const ConnectionOptions = struct {
     trace: bool = false,
     no_responders: bool = true,
     max_scratch_size: usize = 1024 * 1024 * 10,
+
+    /// Ceiling on an inbound protocol control line that arrives split across
+    /// reads, and on the total size (headers plus payload) of an inbound
+    /// message. Both are memory guards against a server that never terminates
+    /// a line or announces a length it does not send - not conformance checks,
+    /// so both defaults sit well above anything a conformant server produces.
+    /// Raise `max_control_line` to match a server configured with a larger
+    /// `max_control_line` than the default.
+    max_control_line: usize = parser_mod.default_max_control_line,
+    max_message_size: usize = parser_mod.default_max_message_size,
     ping_interval: Io.Duration = .fromSeconds(120), // .zero = disabled
     max_pings_out: u32 = 2, // max unanswered keep-alive PINGs
 
@@ -536,7 +547,12 @@ pub const Connection = struct {
             .write_buffer = WriteBuffer.init(allocator, io, .{ .max_size = options.write_buffer_limit, .soft_limit = true }),
             .subscriptions = std.AutoHashMap(u64, *Subscription).init(allocator),
             .response_manager = ResponseManager.init(allocator, io),
-            .parser = Parser.init(allocator, io),
+            .parser = blk: {
+                var parser = Parser.init(allocator, io);
+                parser.max_control_line = options.max_control_line;
+                parser.max_message_size = options.max_message_size;
+                break :blk parser;
+            },
             .scratch = std.heap.ArenaAllocator.init(allocator),
             .ping_time = io_util.now(io),
         };

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -17,8 +17,28 @@ const Message = @import("message.zig").Message;
 const MessagePool = @import("message.zig").MessagePool;
 const log = @import("log.zig").log;
 
-/// Maximum size for control line operations (MSG arguments, INFO, ERR, etc.)
+/// Size of the outbound control line buffer (MSG arguments, INFO, ERR, etc.).
+/// This is a sizing hint for the fast path, not a limit on what the server may
+/// send us - see `default_max_control_line`.
 pub const MAX_CONTROL_LINE_SIZE = 4096;
+
+/// Ceiling on an inbound control line that arrives split across reads.
+///
+/// This is a memory guard, not a protocol conformance check. The server's own
+/// limit is operator-configurable (`max_control_line`), and a cluster INFO with
+/// many `connect_urls` is the realistic case for a large one, so the default is
+/// deliberately far above anything a conformant server sends rather than equal
+/// to the server's default. Neither nats.go nor nats.c bounds this at all; the
+/// point here is only that a server which never terminates a line cannot grow
+/// the buffer until the process dies.
+pub const default_max_control_line = 64 * 1024;
+
+/// Ceiling on the total size (headers plus payload) of an inbound MSG/HMSG.
+///
+/// The server applies the same total-size semantics to inbound PUB/HPUB against
+/// its own max_payload. Sized well above a typical negotiated max_payload so
+/// that raising the server limit does not require touching this.
+pub const default_max_message_size = 64 * 1024 * 1024;
 
 pub const ParserState = enum {
     OP_START,
@@ -73,6 +93,8 @@ pub const Parser = struct {
     arg_buf_rec: std.ArrayList(u8), // The actual arg buffer storage
     arg_buf: ?*std.ArrayList(u8) = null, // Nullable pointer, null = fast path
     msg_pool: MessagePool,
+    max_control_line: usize = default_max_control_line,
+    max_message_size: usize = default_max_message_size,
 
     const Self = @This();
 
@@ -102,7 +124,19 @@ pub const Parser = struct {
         }
         self.ma = .{};
         self.arg_buf = null; // Reset to fast path
-        self.arg_buf_rec.clearRetainingCapacity();
+        // Hand back a buffer that a large control line grew: retaining it
+        // would pin that memory for the life of the connection.
+        if (self.arg_buf_rec.capacity > MAX_CONTROL_LINE_SIZE) {
+            self.arg_buf_rec.clearAndFree(self.allocator);
+        } else {
+            self.arg_buf_rec.clearRetainingCapacity();
+        }
+    }
+
+    /// Append one byte of a split control line, refusing to grow past the limit.
+    fn appendArgByte(self: *Self, arg_buf: *std.ArrayList(u8), b: u8) !void {
+        if (arg_buf.items.len >= self.max_control_line) return error.ControlLineTooLarge;
+        try arg_buf.append(self.allocator, b);
     }
 
     pub fn parse(self: *Self, conn: anytype, buf: []const u8) !void {
@@ -196,7 +230,7 @@ pub const Parser = struct {
                         else => {
                             // Only accumulate if we're in split buffer mode
                             if (self.arg_buf) |arg_buf| {
-                                try arg_buf.append(self.allocator, b);
+                                try self.appendArgByte(arg_buf, b);
                             }
                         },
                     }
@@ -393,7 +427,7 @@ pub const Parser = struct {
                         else => {
                             // Only accumulate if we're in split buffer mode
                             if (self.arg_buf) |arg_buf| {
-                                try arg_buf.append(self.allocator, b);
+                                try self.appendArgByte(arg_buf, b);
                             }
                         },
                     }
@@ -466,7 +500,7 @@ pub const Parser = struct {
                         else => {
                             // Only accumulate if we're in split buffer mode
                             if (self.arg_buf) |arg_buf| {
-                                try arg_buf.append(self.allocator, b);
+                                try self.appendArgByte(arg_buf, b);
                             }
                         },
                     }
@@ -486,6 +520,7 @@ pub const Parser = struct {
             // Set up arg_buf for next parse() call
             try self.setupArgBuf();
             const remaining_args = buf[self.after_space .. i - self.drop];
+            if (remaining_args.len > self.max_control_line) return error.ControlLineTooLarge;
             try self.arg_buf.?.appendSlice(self.allocator, remaining_args);
         }
     }
@@ -540,6 +575,11 @@ pub const Parser = struct {
         const sid = try std.fmt.parseInt(u64, sid_str, 10);
 
         const total_len = try std.fmt.parseInt(usize, total_len_str, 10);
+
+        // Refuse to size an allocation from an unbounded number off the wire.
+        // Mirrors the server, which bounds the same total - headers included -
+        // against its max_payload on the way in.
+        if (total_len > self.max_message_size) return error.MessageTooLarge;
 
         var hdr_len: usize = 0;
         if (hdr_len_str) |str| {
@@ -850,4 +890,75 @@ test "parser multiple lines" {
             try std.testing.expect(false);
         }
     }
+}
+
+test "unterminated control line is bounded" {
+    const testing = std.testing;
+
+    var parser = Parser.init(testing.allocator, std.testing.io);
+    defer parser.deinit();
+    parser.max_control_line = 512; // keep the test cheap
+
+    var mock_conn = MockConnection{};
+    defer mock_conn.deinit();
+
+    // A server that opens an INFO and never terminates it. Feed it in chunks,
+    // as a real socket would, so the split-buffer path does the accumulating.
+    const chunk = "x" ** 64;
+    try parser.parse(&mock_conn, "INFO {");
+
+    var err: ?anyerror = null;
+    var sent: usize = 0;
+    while (sent < 4096) : (sent += chunk.len) {
+        parser.parse(&mock_conn, chunk) catch |e| {
+            err = e;
+            break;
+        };
+    }
+
+    try testing.expectEqual(@as(?anyerror, error.ControlLineTooLarge), err);
+    // The buffer stopped growing at the limit rather than tracking the input.
+    try testing.expect(parser.arg_buf_rec.items.len <= parser.max_control_line);
+}
+
+test "reset gives back an oversized control line buffer" {
+    const testing = std.testing;
+
+    var parser = Parser.init(testing.allocator, std.testing.io);
+    defer parser.deinit();
+
+    var mock_conn = MockConnection{};
+    defer mock_conn.deinit();
+
+    try parser.parse(&mock_conn, "INFO {");
+    const big = "y" ** (MAX_CONTROL_LINE_SIZE * 2);
+    try parser.parse(&mock_conn, big);
+    try testing.expect(parser.arg_buf_rec.capacity > MAX_CONTROL_LINE_SIZE);
+
+    parser.reset();
+    try testing.expectEqual(@as(usize, 0), parser.arg_buf_rec.capacity);
+}
+
+test "oversized MSG length is refused before allocating" {
+    const testing = std.testing;
+
+    var parser = Parser.init(testing.allocator, std.testing.io);
+    defer parser.deinit();
+    parser.max_message_size = 1024;
+
+    var mock_conn = MockConnection{};
+    defer mock_conn.deinit();
+
+    // Announce far more than the parser will allocate. Without the bound this
+    // sizes the payload buffer straight from the wire.
+    try testing.expectError(
+        error.MessageTooLarge,
+        parser.parse(&mock_conn, "MSG foo 1 4294967296\r\n"),
+    );
+    try testing.expectEqual(@as(u32, 0), mock_conn.msg_count);
+
+    // A message inside the limit still parses.
+    parser.reset();
+    try parser.parse(&mock_conn, "MSG foo 1 5\r\nhello\r\n");
+    try testing.expectEqual(@as(u32, 1), mock_conn.msg_count);
 }


### PR DESCRIPTION
The parser grew its split-line argument buffer without limit, and sized the payload allocation straight from the length on the wire. A server that never terminates a control line, or announces a length it does not send, could drive the process out of memory.

### First: the reference clients don't do this either

Before changing anything I fast-forwarded the reference repos (nats.c +214 commits, nats.go +119, nats-server +1647). Nothing about this changed, and the history says why:

- **nats.go** — `parser.go` had **zero** commits in that range. Line 390 still reads `// FIXME, check max len`, introduced by `2245b14` on **2012-12-17**. Thirteen years untouched.
- **nats.c** — `src/parser.c` also zero commits. `MAX_CONTROL_LINE_SIZE` still only sizes `parser.scratch[]`; `natsBuf_Append` mallocs past it through `natsBuf_Expand`.
- **nats-server** — still enforces, now at 11 `overMaxControlLineLimit(arg, mcl)` call sites.

That asymmetry looks like the threat model rather than an oversight: the server bounds untrusted clients, clients trust the server the operator pointed them at. This parser inherited the client side faithfully.

So this is hardening past the reference clients, not a regression being repaired — which is what shapes the limits below.

### What changed

1. **Inbound control line bounded** — `default_max_control_line`, 64 KB.

   Deliberately *not* `MAX_CONTROL_LINE_SIZE`. The server's limit is operator-configurable (`max_control_line`), and a cluster INFO with many `connect_urls` is the realistic large line — the server applies `mcl` to INFO too. Bounding at 4096 would break deployments where nats.go and nats.c work fine. `MAX_CONTROL_LINE_SIZE` keeps its existing job of sizing the outbound buffer.

2. **Inbound MSG/HMSG total bounded** — `default_max_message_size`, 64 MB. Mirrors the server, which bounds the same total — headers included — against `max_payload` on the way in.

3. **`reset()` returns an oversized buffer** instead of pinning what one large line grew for the life of the connection.

4. Both exposed as `ConnectionOptions.max_control_line` / `.max_message_size`.

### Not addressed: the sticky CR

`drop` is set on `\r` and cleared only on `\n`, so a stray mid-line CR truncates the last argument byte — for a length field, a framing desync.

I checked rather than assumed: this is character-for-character identical in `nats.go`, **and in `nats-server`'s own parser**. The side that must survive hostile input keeps the same CR handling and adds only the length check. Diverging from the server on input no conformant server emits is not a trade worth making. Revisit if a concrete misparse ever shows up.

### Verification

Three new unit tests, each confirmed to fail with its bound removed:

| test | without the bound |
|---|---|
| unterminated control line is bounded | `expected error.ControlLineTooLarge, found null` |
| reset gives back an oversized buffer | `expected 0, found 9677` |
| oversized MSG length is refused | `expected error.MessageTooLarge, found void` |

`./check.sh`: 135/135 unit, 179/179 e2e.