### PR TITLE
Subscribe before creating the consumer, and check the one that already exists

### DIFF
--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -685,8 +685,9 @@ pub const JetStream = struct {
         return try self.nc.allocator.dupe(u8, streams[0]);
     }
 
-    /// Get existing consumer or create new one based on configuration
-    fn getOrCreateConsumer(self: JetStream, stream_name: []const u8, subject: ?[]const u8, durable: ?[]const u8, base_config: ?ConsumerConfig, is_pull: bool, queue: ?[]const u8) !Result(ConsumerInfo) {
+    /// Fill in the consumer config fields that follow from the subscribe call
+    /// itself rather than from the caller's config.
+    fn buildConsumerConfig(base_config: ?ConsumerConfig, subject: ?[]const u8, durable: ?[]const u8, is_pull: bool, queue: ?[]const u8) ConsumerConfig {
         // Start with base config or empty config
         var config = base_config orelse ConsumerConfig{};
 
@@ -717,22 +718,65 @@ pub const JetStream = struct {
             config.max_expires = null;
         }
 
-        // If durable is provided, try to get existing consumer first
-        if (durable) |consumer_name| {
-            // Try to get existing consumer info
-            if (self.getConsumerInfo(stream_name, consumer_name)) |existing_info| {
-                log.debug("Found existing consumer: {s}", .{consumer_name});
-                return existing_info;
-            } else |err| switch (err) {
-                error.ConsumerNotFound => {
-                    // Consumer doesn't exist, we'll create it below
-                    log.debug("Consumer {s} not found, creating new one", .{consumer_name});
-                },
-                else => return err, // Other errors should be propagated
-            }
-        }
+        return config;
+    }
 
-        // Create the consumer
+    /// Look up a named consumer, returning null when it does not exist yet.
+    fn lookupConsumer(self: JetStream, stream_name: []const u8, durable: ?[]const u8) !?Result(ConsumerInfo) {
+        const consumer_name = durable orelse return null;
+
+        if (self.getConsumerInfo(stream_name, consumer_name)) |existing_info| {
+            log.debug("Found existing consumer: {s}", .{consumer_name});
+            return existing_info;
+        } else |err| switch (err) {
+            error.ConsumerNotFound => {
+                log.debug("Consumer {s} not found, creating new one", .{consumer_name});
+                return null;
+            },
+            else => return err, // Other errors should be propagated
+        }
+    }
+
+    /// Take ownership of a looked up consumer info, leaving null behind so the
+    /// errdefer guarding the lookup does not release it a second time.
+    fn takeConsumerInfo(info: *?Result(ConsumerInfo)) ?Result(ConsumerInfo) {
+        defer info.* = null;
+        return info.*;
+    }
+
+    /// Everything a push subscribe needs to know before it can subscribe: the
+    /// consumer to use if it already exists, the config to create it with if it
+    /// does not, and the subject the server will deliver to either way.
+    const PushConsumerSetup = struct {
+        existing: ?Result(ConsumerInfo),
+        config: ConsumerConfig,
+        deliver_subject: []const u8,
+    };
+
+    /// Look up an existing consumer before subscribing: when one is already
+    /// there, the server pushes to its deliver subject, not to ours.
+    fn preparePushConsumer(self: JetStream, stream_name: []const u8, subject: ?[]const u8, durable: ?[]const u8, base_config: ConsumerConfig, queue: ?[]const u8) !PushConsumerSetup {
+        const existing = try self.lookupConsumer(stream_name, durable);
+        errdefer if (existing) |info| info.deinit();
+
+        const config = buildConsumerConfig(base_config, subject, durable, false, queue);
+
+        return .{
+            .existing = existing,
+            .config = config,
+            .deliver_subject = if (existing) |info|
+                info.value.config.deliver_subject.?
+            else
+                config.deliver_subject.?,
+        };
+    }
+
+    /// Get existing consumer or create new one based on configuration
+    fn getOrCreateConsumer(self: JetStream, stream_name: []const u8, subject: ?[]const u8, durable: ?[]const u8, base_config: ?ConsumerConfig, is_pull: bool, queue: ?[]const u8) !Result(ConsumerInfo) {
+        const config = buildConsumerConfig(base_config, subject, durable, is_pull, queue);
+
+        if (try self.lookupConsumer(stream_name, durable)) |existing_info| return existing_info;
+
         return try self.addConsumer(stream_name, config);
     }
 
@@ -1328,18 +1372,21 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        // Create or get consumer with complete config
-        var consumer_info = try self.getOrCreateConsumer(stream_name, subject, options.durable, config, false, null);
-        errdefer consumer_info.deinit();
-
-        const deliver_subject = consumer_info.value.config.deliver_subject.?;
+        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, null);
+        errdefer if (setup.existing) |info| info.deinit();
 
         // Use the reusable JetStream handler wrapper
         const JSHandler = JetStreamHandler(handlerFn);
 
         // Subscribe to the delivery subject
-        const subscription = try self.nc.subscribe(deliver_subject, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
-        errdefer self.nc.unsubscribe(subscription);
+        const subscription = try self.nc.subscribe(setup.deliver_subject, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
+        errdefer subscription.deinit();
+
+        // Create the consumer only once the delivery subscription exists: the
+        // SUB frame is queued ahead of the create request, so the server has
+        // interest in the deliver subject before it pushes anything to it.
+        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
+        errdefer consumer_info.deinit();
 
         applyPendingLimits(subscription, &consumer_info.value.config);
 
@@ -1386,15 +1433,18 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        // Create or get consumer with proper config
-        var consumer_info = try self.getOrCreateConsumer(stream_name, subject, options.durable, config, false, null);
-        errdefer consumer_info.deinit();
-
-        const deliver_subject = consumer_info.value.config.deliver_subject.?;
+        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, null);
+        errdefer if (setup.existing) |info| info.deinit();
 
         // Create synchronous subscription (no callback handler)
-        const subscription = try self.nc.subscribeSync(deliver_subject);
-        errdefer self.nc.unsubscribe(subscription);
+        const subscription = try self.nc.subscribeSync(setup.deliver_subject);
+        errdefer subscription.deinit();
+
+        // Create the consumer only once the delivery subscription exists: the
+        // SUB frame is queued ahead of the create request, so the server has
+        // interest in the deliver subject before it pushes anything to it.
+        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
+        errdefer consumer_info.deinit();
 
         applyPendingLimits(subscription, &consumer_info.value.config);
 
@@ -1440,18 +1490,21 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        // Create or get consumer with queue group
-        var consumer_info = try self.getOrCreateConsumer(stream_name, subject, options.durable, config, false, queue);
-        errdefer consumer_info.deinit();
-
-        const deliver_subject = consumer_info.value.config.deliver_subject.?;
+        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, queue);
+        errdefer if (setup.existing) |info| info.deinit();
 
         // Use the reusable JetStream handler wrapper
         const JSHandler = JetStreamHandler(handlerFn);
 
         // Subscribe to the delivery subject with queue group
-        const subscription = try self.nc.queueSubscribe(deliver_subject, queue, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
-        errdefer self.nc.unsubscribe(subscription);
+        const subscription = try self.nc.queueSubscribe(setup.deliver_subject, queue, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
+        errdefer subscription.deinit();
+
+        // Create the consumer only once the delivery subscription exists: the
+        // SUB frame is queued ahead of the create request, so the server has
+        // interest in the deliver subject before it pushes anything to it.
+        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
+        errdefer consumer_info.deinit();
 
         applyPendingLimits(subscription, &consumer_info.value.config);
 
@@ -1498,15 +1551,18 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        // Create or get consumer with queue group
-        var consumer_info = try self.getOrCreateConsumer(stream_name, subject, options.durable, config, false, queue);
-        errdefer consumer_info.deinit();
-
-        const deliver_subject = consumer_info.value.config.deliver_subject.?;
+        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, queue);
+        errdefer if (setup.existing) |info| info.deinit();
 
         // Create synchronous subscription with queue group
-        const subscription = try self.nc.queueSubscribeSync(deliver_subject, queue);
-        errdefer self.nc.unsubscribe(subscription);
+        const subscription = try self.nc.queueSubscribeSync(setup.deliver_subject, queue);
+        errdefer subscription.deinit();
+
+        // Create the consumer only once the delivery subscription exists: the
+        // SUB frame is queued ahead of the create request, so the server has
+        // interest in the deliver subject before it pushes anything to it.
+        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
+        errdefer consumer_info.deinit();
 
         applyPendingLimits(subscription, &consumer_info.value.config);
 
@@ -1534,15 +1590,6 @@ pub const JetStream = struct {
 
         defer if (options.stream == null and subject != null) self.nc.allocator.free(stream_name);
 
-        // Create or get consumer (pull consumers require a name)
-        var consumer_info = try self.getOrCreateConsumer(stream_name, subject, durable, options.config, true, null);
-        errdefer consumer_info.deinit();
-
-        // Get the consumer name (should be set from durable parameter)
-        const consumer_name = consumer_info.value.config.name orelse
-            consumer_info.value.config.durable_name orelse
-            durable;
-
         // Generate unique inbox prefix for this pull subscription
         const inbox_base = try inbox.newInbox(self.nc.allocator);
         defer self.nc.allocator.free(inbox_base);
@@ -1554,9 +1601,19 @@ pub const JetStream = struct {
         const wildcard_subject = try std.fmt.allocPrint(self.nc.allocator, "{s}*", .{inbox_prefix});
         defer self.nc.allocator.free(wildcard_subject);
 
-        // Create the persistent wildcard inbox subscription
+        // Create the persistent wildcard inbox subscription before the consumer
+        // exists, so no response can be delivered without local interest.
         const inbox_subscription = try self.nc.subscribeSync(wildcard_subject);
-        errdefer self.nc.unsubscribe(inbox_subscription);
+        errdefer inbox_subscription.deinit();
+
+        // Create or get consumer (pull consumers require a name)
+        var consumer_info = try self.getOrCreateConsumer(stream_name, subject, durable, options.config, true, null);
+        errdefer consumer_info.deinit();
+
+        // Get the consumer name (should be set from durable parameter)
+        const consumer_name = consumer_info.value.config.name orelse
+            consumer_info.value.config.durable_name orelse
+            durable;
 
         applyPendingLimits(inbox_subscription, &consumer_info.value.config);
 

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -250,6 +250,8 @@ pub const ConsumerInfo = struct {
     num_waiting: u64,
     /// The number of pending pull requests
     num_pending: u64,
+    /// Whether a push consumer already has a subscription bound to it
+    push_bound: ?bool = null,
     /// When this consumer was created
     created: []const u8,
 };
@@ -721,6 +723,112 @@ pub const JetStream = struct {
         return config;
     }
 
+    fn optStrEql(a: ?[]const u8, b: ?[]const u8) bool {
+        const lhs = a orelse return b == null;
+        const rhs = b orelse return false;
+        return std.mem.eql(u8, lhs, rhs);
+    }
+
+    fn configMismatch(comptime field: []const u8, requested: anytype, actual: anytype) error{ConsumerConfigMismatch} {
+        log.err("existing consumer has " ++ field ++ " {any}, but {any} was requested", .{ actual, requested });
+        return error.ConsumerConfigMismatch;
+    }
+
+    fn configMismatchStr(comptime field: []const u8, requested: ?[]const u8, actual: ?[]const u8) error{ConsumerConfigMismatch} {
+        log.err("existing consumer has " ++ field ++ " {?s}, but {?s} was requested", .{ actual, requested });
+        return error.ConsumerConfigMismatch;
+    }
+
+    /// Reject an existing consumer that does not deliver what the caller asked
+    /// for, rather than silently attaching to it. Mirrors processConsInfo and
+    /// checkConfig in nats.go, and _processConsInfo in nats.c.
+    ///
+    /// Only fields the caller can be shown to have set are compared. Several
+    /// ConsumerConfig fields are plain values with a default rather than
+    /// optionals, so a value equal to that default cannot be told apart from
+    /// one that was never set, and is treated as unset - the same accommodation
+    /// nats.go makes for its own zero values.
+    fn checkExistingConsumer(existing: *const ConsumerInfo, requested: ConsumerConfig, is_pull: bool, subject: ?[]const u8, queue: ?[]const u8) !void {
+        const config = &existing.config;
+        const defaults = ConsumerConfig{};
+
+        // A consumer whose filter does not cover the requested subject would
+        // deliver nothing, or the wrong thing. Unlike nats.go, subscribing
+        // without a subject is allowed against a filtered consumer: binding to
+        // a durable by name alone is a normal way to use this API.
+        if (subject) |s| {
+            if (config.filter_subject) |filter| {
+                if (!std.mem.eql(u8, s, filter)) return configMismatchStr("filter_subject", s, filter);
+            }
+        }
+
+        // Pull and push consumers are not interchangeable, and the deliver
+        // subject is what tells them apart.
+        if (is_pull) {
+            if (config.deliver_subject != null) return error.PullSubscribeToPushConsumer;
+        } else {
+            if (config.deliver_subject == null) return error.PushSubscribeToPullConsumer;
+
+            if (config.deliver_group) |group| {
+                // A consumer with a deliver group only delivers to members of
+                // that group, so a plain subscription receives nothing.
+                const q = queue orelse return configMismatchStr("deliver_group", null, group);
+                if (!std.mem.eql(u8, q, group)) return configMismatchStr("deliver_group", q, group);
+            } else if (queue) |q| {
+                return configMismatchStr("deliver_group", q, null);
+            } else if (existing.push_bound orelse false) {
+                // Two plain subscriptions to one push consumer split its
+                // delivery between them at random.
+                return error.ConsumerAlreadyBound;
+            }
+        }
+
+        if (requested.description) |v| {
+            if (!optStrEql(v, config.description)) return configMismatchStr("description", v, config.description);
+        }
+        if (requested.deliver_policy != defaults.deliver_policy and requested.deliver_policy != config.deliver_policy) {
+            return configMismatch("deliver_policy", requested.deliver_policy, config.deliver_policy);
+        }
+        if (requested.opt_start_seq) |v| {
+            if (v != config.opt_start_seq) return configMismatch("opt_start_seq", v, config.opt_start_seq);
+        }
+        if (requested.opt_start_time) |v| {
+            if (!optStrEql(v, config.opt_start_time)) return configMismatchStr("opt_start_time", v, config.opt_start_time);
+        }
+        if (requested.ack_policy != defaults.ack_policy and requested.ack_policy != config.ack_policy) {
+            return configMismatch("ack_policy", requested.ack_policy, config.ack_policy);
+        }
+        if (requested.ack_wait != defaults.ack_wait and requested.ack_wait != config.ack_wait) {
+            return configMismatch("ack_wait", requested.ack_wait, config.ack_wait);
+        }
+        if (requested.max_deliver != defaults.max_deliver and requested.max_deliver != config.max_deliver) {
+            return configMismatch("max_deliver", requested.max_deliver, config.max_deliver);
+        }
+        if (requested.replay_policy != defaults.replay_policy and requested.replay_policy != config.replay_policy) {
+            return configMismatch("replay_policy", requested.replay_policy, config.replay_policy);
+        }
+        if (requested.rate_limit_bps) |v| {
+            if (v != config.rate_limit_bps) return configMismatch("rate_limit_bps", v, config.rate_limit_bps);
+        }
+        if (requested.max_ack_pending != defaults.max_ack_pending and requested.max_ack_pending != config.max_ack_pending) {
+            return configMismatch("max_ack_pending", requested.max_ack_pending, config.max_ack_pending);
+        }
+        if (requested.idle_heartbeat) |v| {
+            if (v != config.idle_heartbeat) return configMismatch("idle_heartbeat", v, config.idle_heartbeat);
+        }
+        if (requested.max_waiting) |v| {
+            if (v != config.max_waiting) return configMismatch("max_waiting", v, config.max_waiting);
+        }
+        if (requested.num_replicas) |v| {
+            if (v != config.num_replicas) return configMismatch("num_replicas", v, config.num_replicas);
+        }
+        // Flow control the caller did not ask for is handled by the library
+        // either way, so only an unmet request for it is a mismatch.
+        if (requested.flow_control orelse false) {
+            if (!(config.flow_control orelse false)) return configMismatch("flow_control", true, config.flow_control);
+        }
+    }
+
     /// Look up a named consumer, returning null when it is unnamed or does
     /// not exist yet.
     fn lookupConsumer(self: JetStream, stream_name: []const u8, name: ?[]const u8) !?Result(ConsumerInfo) {
@@ -775,10 +883,10 @@ pub const JetStream = struct {
         // Two passes at most: the second one always has a consumer to attach
         // to, so it returns before reaching addConsumer again.
         while (true) {
-            const deliver_subject = if (existing) |info|
-                info.value.config.deliver_subject.?
-            else
-                config.deliver_subject.?;
+            const deliver_subject = if (existing) |info| blk: {
+                try checkExistingConsumer(&info.value, base_config, false, subject, queue);
+                break :blk info.value.config.deliver_subject.?;
+            } else config.deliver_subject.?;
 
             const subscription = try subscriber.subscribe(deliver_subject);
             errdefer subscription.deinit();
@@ -809,7 +917,11 @@ pub const JetStream = struct {
     fn getOrCreateConsumer(self: JetStream, stream_name: []const u8, subject: ?[]const u8, durable: ?[]const u8, base_config: ?ConsumerConfig, is_pull: bool, queue: ?[]const u8) !Result(ConsumerInfo) {
         const config = buildConsumerConfig(base_config, subject, durable, is_pull, queue);
 
-        if (try self.lookupConsumer(stream_name, durable)) |existing_info| return existing_info;
+        if (try self.lookupConsumer(stream_name, config.name orelse config.durable_name)) |existing_info| {
+            errdefer existing_info.deinit();
+            try checkExistingConsumer(&existing_info.value, base_config orelse .{}, is_pull, subject, queue);
+            return existing_info;
+        }
 
         return try self.addConsumer(stream_name, config);
     }

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -721,9 +721,10 @@ pub const JetStream = struct {
         return config;
     }
 
-    /// Look up a named consumer, returning null when it does not exist yet.
-    fn lookupConsumer(self: JetStream, stream_name: []const u8, durable: ?[]const u8) !?Result(ConsumerInfo) {
-        const consumer_name = durable orelse return null;
+    /// Look up a named consumer, returning null when it is unnamed or does
+    /// not exist yet.
+    fn lookupConsumer(self: JetStream, stream_name: []const u8, name: ?[]const u8) !?Result(ConsumerInfo) {
+        const consumer_name = name orelse return null;
 
         if (self.getConsumerInfo(stream_name, consumer_name)) |existing_info| {
             log.debug("Found existing consumer: {s}", .{consumer_name});
@@ -744,31 +745,64 @@ pub const JetStream = struct {
         return info.*;
     }
 
-    /// Everything a push subscribe needs to know before it can subscribe: the
-    /// consumer to use if it already exists, the config to create it with if it
-    /// does not, and the subject the server will deliver to either way.
-    const PushConsumerSetup = struct {
-        existing: ?Result(ConsumerInfo),
-        config: ConsumerConfig,
-        deliver_subject: []const u8,
+    /// A delivery subscription together with the consumer it delivers from.
+    const PushConsumerSubscription = struct {
+        subscription: *Subscription,
+        consumer_info: Result(ConsumerInfo),
     };
 
-    /// Look up an existing consumer before subscribing: when one is already
-    /// there, the server pushes to its deliver subject, not to ours.
-    fn preparePushConsumer(self: JetStream, stream_name: []const u8, subject: ?[]const u8, durable: ?[]const u8, base_config: ConsumerConfig, queue: ?[]const u8) !PushConsumerSetup {
-        const existing = try self.lookupConsumer(stream_name, durable);
-        errdefer if (existing) |info| info.deinit();
-
+    /// Subscribe to a push consumer's deliver subject and then make sure the
+    /// consumer exists, in that order: the SUB frame is queued ahead of the
+    /// create request, so the server has interest in the deliver subject
+    /// before it can push anything to it.
+    ///
+    /// `subscriber` performs the subscribe itself, which differs per entry
+    /// point (callback or sync, with or without a queue group). It may be
+    /// called twice, so it must not consume anything it is given.
+    fn subscribeToPushConsumer(self: JetStream, stream_name: []const u8, subject: ?[]const u8, durable: ?[]const u8, base_config: ConsumerConfig, queue: ?[]const u8, subscriber: anytype) !PushConsumerSubscription {
         const config = buildConsumerConfig(base_config, subject, durable, false, queue);
 
-        return .{
-            .existing = existing,
-            .config = config,
-            .deliver_subject = if (existing) |info|
+        // The name addConsumer would target, which the caller can also have
+        // supplied through the config rather than through `durable`. Both
+        // official clients look the consumer up under either name.
+        const consumer_name = config.name orelse config.durable_name;
+
+        // When the consumer is already there, the server delivers to its
+        // deliver subject rather than to the one we would have asked for.
+        var existing = try self.lookupConsumer(stream_name, consumer_name);
+        errdefer if (existing) |info| info.deinit();
+
+        // Two passes at most: the second one always has a consumer to attach
+        // to, so it returns before reaching addConsumer again.
+        while (true) {
+            const deliver_subject = if (existing) |info|
                 info.value.config.deliver_subject.?
             else
-                config.deliver_subject.?,
-        };
+                config.deliver_subject.?;
+
+            const subscription = try subscriber.subscribe(deliver_subject);
+            errdefer subscription.deinit();
+
+            if (takeConsumerInfo(&existing)) |info| {
+                return .{ .subscription = subscription, .consumer_info = info };
+            }
+
+            if (self.addConsumer(stream_name, config)) |info| {
+                return .{ .subscription = subscription, .consumer_info = info };
+            } else |err| switch (err) {
+                // Another client created the consumer between our lookup and
+                // this create, so it owns the deliver subject now. Attach to
+                // the consumer that won and subscribe where it actually
+                // delivers. Look it up before dropping the subscription, so a
+                // failing lookup leaves exactly one cleanup to run.
+                error.ConsumerAlreadyExists, error.ConsumerNameExist, error.ConsumerExistingActive => {
+                    const winner = try self.lookupConsumer(stream_name, consumer_name) orelse return err;
+                    subscription.deinit();
+                    existing = winner;
+                },
+                else => return err,
+            }
+        }
     }
 
     /// Get existing consumer or create new one based on configuration
@@ -1372,30 +1406,31 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, null);
-        errdefer if (setup.existing) |info| info.deinit();
-
         // Use the reusable JetStream handler wrapper
         const JSHandler = JetStreamHandler(handlerFn);
 
-        // Subscribe to the delivery subject
-        const subscription = try self.nc.subscribe(setup.deliver_subject, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
-        errdefer subscription.deinit();
+        const subscriber = struct {
+            nc: *Connection,
+            handler_args: @TypeOf(handler_args),
+            manual_ack: bool,
 
-        // Create the consumer only once the delivery subscription exists: the
-        // SUB frame is queued ahead of the create request, so the server has
-        // interest in the deliver subject before it pushes anything to it.
-        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
-        errdefer consumer_info.deinit();
+            fn subscribe(sub_ctx: @This(), deliver_subject: []const u8) !*Subscription {
+                return sub_ctx.nc.subscribe(deliver_subject, JSHandler.wrappedHandler, .{ sub_ctx.nc, sub_ctx.handler_args, sub_ctx.manual_ack });
+            }
+        }{ .nc = self.nc, .handler_args = handler_args, .manual_ack = options.manual_ack };
 
-        applyPendingLimits(subscription, &consumer_info.value.config);
+        var push = try self.subscribeToPushConsumer(stream_name, subject, options.durable, config, null, subscriber);
+        errdefer push.subscription.deinit();
+        errdefer push.consumer_info.deinit();
+
+        applyPendingLimits(push.subscription, &push.consumer_info.value.config);
 
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
         js_sub.* = JetStreamSubscription{
-            .subscription = subscription,
+            .subscription = push.subscription,
             .js = self,
-            .consumer_info = consumer_info,
+            .consumer_info = push.consumer_info,
             .deliver_subject_owned = generated_deliver_subject,
         };
 
@@ -1433,27 +1468,27 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, null);
-        errdefer if (setup.existing) |info| info.deinit();
+        // Subscribe synchronously, without a callback handler
+        const subscriber = struct {
+            nc: *Connection,
 
-        // Create synchronous subscription (no callback handler)
-        const subscription = try self.nc.subscribeSync(setup.deliver_subject);
-        errdefer subscription.deinit();
+            fn subscribe(sub_ctx: @This(), deliver_subject: []const u8) !*Subscription {
+                return sub_ctx.nc.subscribeSync(deliver_subject);
+            }
+        }{ .nc = self.nc };
 
-        // Create the consumer only once the delivery subscription exists: the
-        // SUB frame is queued ahead of the create request, so the server has
-        // interest in the deliver subject before it pushes anything to it.
-        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
-        errdefer consumer_info.deinit();
+        var push = try self.subscribeToPushConsumer(stream_name, subject, options.durable, config, null, subscriber);
+        errdefer push.subscription.deinit();
+        errdefer push.consumer_info.deinit();
 
-        applyPendingLimits(subscription, &consumer_info.value.config);
+        applyPendingLimits(push.subscription, &push.consumer_info.value.config);
 
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
         js_sub.* = JetStreamSubscription{
-            .subscription = subscription,
+            .subscription = push.subscription,
             .js = self,
-            .consumer_info = consumer_info,
+            .consumer_info = push.consumer_info,
             .deliver_subject_owned = generated_deliver_subject,
         };
         return js_sub;
@@ -1490,30 +1525,32 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, queue);
-        errdefer if (setup.existing) |info| info.deinit();
-
         // Use the reusable JetStream handler wrapper
         const JSHandler = JetStreamHandler(handlerFn);
 
-        // Subscribe to the delivery subject with queue group
-        const subscription = try self.nc.queueSubscribe(setup.deliver_subject, queue, JSHandler.wrappedHandler, .{ self.nc, handler_args, options.manual_ack });
-        errdefer subscription.deinit();
+        const subscriber = struct {
+            nc: *Connection,
+            queue: []const u8,
+            handler_args: @TypeOf(handler_args),
+            manual_ack: bool,
 
-        // Create the consumer only once the delivery subscription exists: the
-        // SUB frame is queued ahead of the create request, so the server has
-        // interest in the deliver subject before it pushes anything to it.
-        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
-        errdefer consumer_info.deinit();
+            fn subscribe(sub_ctx: @This(), deliver_subject: []const u8) !*Subscription {
+                return sub_ctx.nc.queueSubscribe(deliver_subject, sub_ctx.queue, JSHandler.wrappedHandler, .{ sub_ctx.nc, sub_ctx.handler_args, sub_ctx.manual_ack });
+            }
+        }{ .nc = self.nc, .queue = queue, .handler_args = handler_args, .manual_ack = options.manual_ack };
 
-        applyPendingLimits(subscription, &consumer_info.value.config);
+        var push = try self.subscribeToPushConsumer(stream_name, subject, options.durable, config, queue, subscriber);
+        errdefer push.subscription.deinit();
+        errdefer push.consumer_info.deinit();
+
+        applyPendingLimits(push.subscription, &push.consumer_info.value.config);
 
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
         js_sub.* = JetStreamSubscription{
-            .subscription = subscription,
+            .subscription = push.subscription,
             .js = self,
-            .consumer_info = consumer_info,
+            .consumer_info = push.consumer_info,
             .deliver_subject_owned = generated_deliver_subject,
         };
 
@@ -1551,27 +1588,28 @@ pub const JetStream = struct {
             config.deliver_subject = ds;
         }
 
-        var setup = try self.preparePushConsumer(stream_name, subject, options.durable, config, queue);
-        errdefer if (setup.existing) |info| info.deinit();
+        // Subscribe synchronously with a queue group, without a callback handler
+        const subscriber = struct {
+            nc: *Connection,
+            queue: []const u8,
 
-        // Create synchronous subscription with queue group
-        const subscription = try self.nc.queueSubscribeSync(setup.deliver_subject, queue);
-        errdefer subscription.deinit();
+            fn subscribe(sub_ctx: @This(), deliver_subject: []const u8) !*Subscription {
+                return sub_ctx.nc.queueSubscribeSync(deliver_subject, sub_ctx.queue);
+            }
+        }{ .nc = self.nc, .queue = queue };
 
-        // Create the consumer only once the delivery subscription exists: the
-        // SUB frame is queued ahead of the create request, so the server has
-        // interest in the deliver subject before it pushes anything to it.
-        var consumer_info = takeConsumerInfo(&setup.existing) orelse try self.addConsumer(stream_name, setup.config);
-        errdefer consumer_info.deinit();
+        var push = try self.subscribeToPushConsumer(stream_name, subject, options.durable, config, queue, subscriber);
+        errdefer push.subscription.deinit();
+        errdefer push.consumer_info.deinit();
 
-        applyPendingLimits(subscription, &consumer_info.value.config);
+        applyPendingLimits(push.subscription, &push.consumer_info.value.config);
 
         // Create JetStream subscription wrapper
         const js_sub = try self.nc.allocator.create(JetStreamSubscription);
         js_sub.* = JetStreamSubscription{
-            .subscription = subscription,
+            .subscription = push.subscription,
             .js = self,
-            .consumer_info = consumer_info,
+            .consumer_info = push.consumer_info,
             .deliver_subject_owned = generated_deliver_subject,
         };
 

--- a/src/jetstream.zig
+++ b/src/jetstream.zig
@@ -181,30 +181,41 @@ pub const ConsumerConfig = struct {
     durable_name: ?[]const u8 = null,
     /// A short description of the purpose of this consumer
     description: ?[]const u8 = null,
-    /// The point in the stream to receive messages from, either 'all', 'last', 'new', 'by_start_sequence', 'by_start_time', 'last_per_subject'
-    deliver_policy: enum { all, last, new, by_start_sequence, by_start_time, last_per_subject } = .all,
+    /// The point in the stream to receive messages from, either 'all', 'last', 'new', 'by_start_sequence', 'by_start_time', 'last_per_subject'.
+    /// Not sent when null, which the server reads as 'all'.
+    deliver_policy: ?enum { all, last, new, by_start_sequence, by_start_time, last_per_subject } = null,
     /// Used with deliver_policy 'by_start_sequence' to define the sequence to start at
     opt_start_seq: ?u64 = null,
     /// Used with deliver_policy 'by_start_time' to define the time to start at
     opt_start_time: ?[]const u8 = null,
     /// The subject to deliver messages to, omit for pull consumers
     deliver_subject: ?[]const u8 = null,
-    /// How messages are acknowledged, either 'none', 'all', or 'explicit'
-    ack_policy: enum { none, all, explicit } = .explicit,
-    /// How long (in nanoseconds) to allow messages to remain un-acknowledged before attempting redelivery
-    ack_wait: u64 = 30_000_000_000, // 30 seconds
-    /// The number of times a message will be redelivered to consumers if not acknowledged in time
-    max_deliver: i64 = -1,
+    /// How messages are acknowledged, either 'none', 'all', or 'explicit'.
+    /// Not sent when null, which the server reads as 'none' - but the subscribe
+    /// entry points ask for 'explicit' when the caller did not choose, since a
+    /// subscription that silently never acknowledges is not a useful default.
+    ack_policy: ?enum { none, all, explicit } = null,
+    /// How long (in nanoseconds) to allow messages to remain un-acknowledged before attempting redelivery.
+    /// Not sent when null; the server uses 30 seconds for the 'explicit' and
+    /// 'all' ack policies.
+    ack_wait: ?u64 = null,
+    /// The number of times a message will be redelivered to consumers if not acknowledged in time.
+    /// Not sent when null; the server uses -1, no limit.
+    max_deliver: ?i64 = null,
     /// Filter the stream by a single subject
     filter_subject: ?[]const u8 = null,
     /// Filter the stream by multiple subjects
     filter_subjects: ?[]const []const u8 = null,
-    /// How messages are sent, either 'instant' or 'original'
-    replay_policy: enum { instant, original } = .instant,
+    /// How messages are sent, either 'instant' or 'original'.
+    /// Not sent when null, which the server reads as 'instant'.
+    replay_policy: ?enum { instant, original } = null,
     /// The rate at which messages will be delivered to clients, expressed in bit per second
     rate_limit_bps: ?u64 = null,
-    /// The maximum number of messages without acknowledgement that can be outstanding
-    max_ack_pending: i64 = 1000,
+    /// The maximum number of messages without acknowledgement that can be outstanding.
+    /// Not sent when null, which lets the stream's consumer limits apply, and
+    /// where they set nothing the server uses 1000 for consumers that
+    /// acknowledge and no limit for ack policy 'none'.
+    max_ack_pending: ?i64 = null,
     /// If the Consumer is idle for more than this many nano seconds a empty message with Status header 100 will be sent
     idle_heartbeat: ?u64 = null,
     /// For push consumers this will regularly send an empty mess with Status header 100 and a reply subject
@@ -709,6 +720,12 @@ pub const JetStream = struct {
             config.deliver_group = q;
         }
 
+        // A consumer created through subscribe acknowledges explicitly unless
+        // asked otherwise: the server's own default for an omitted ack policy
+        // is 'none', which silently gives up redelivery. nats.go applies the
+        // same default in the same place (js.go:1877).
+        if (config.ack_policy == null) config.ack_policy = .explicit;
+
         // Configure for pull vs push consumer
         if (is_pull) {
             config.deliver_subject = null;
@@ -743,14 +760,11 @@ pub const JetStream = struct {
     /// for, rather than silently attaching to it. Mirrors processConsInfo and
     /// checkConfig in nats.go, and _processConsInfo in nats.c.
     ///
-    /// Only fields the caller can be shown to have set are compared. Several
-    /// ConsumerConfig fields are plain values with a default rather than
-    /// optionals, so a value equal to that default cannot be told apart from
-    /// one that was never set, and is treated as unset - the same accommodation
-    /// nats.go makes for its own zero values.
+    /// Every ConsumerConfig field the caller left null is left alone: null
+    /// means "whatever this consumer already is", so only fields that were
+    /// actually asked for can produce a mismatch.
     fn checkExistingConsumer(existing: *const ConsumerInfo, requested: ConsumerConfig, is_pull: bool, subject: ?[]const u8, queue: ?[]const u8) !void {
         const config = &existing.config;
-        const defaults = ConsumerConfig{};
 
         // A consumer whose filter does not cover the requested subject would
         // deliver nothing, or the wrong thing. Unlike nats.go, subscribing
@@ -786,8 +800,8 @@ pub const JetStream = struct {
         if (requested.description) |v| {
             if (!optStrEql(v, config.description)) return configMismatchStr("description", v, config.description);
         }
-        if (requested.deliver_policy != defaults.deliver_policy and requested.deliver_policy != config.deliver_policy) {
-            return configMismatch("deliver_policy", requested.deliver_policy, config.deliver_policy);
+        if (requested.deliver_policy) |v| {
+            if (v != config.deliver_policy) return configMismatch("deliver_policy", v, config.deliver_policy);
         }
         if (requested.opt_start_seq) |v| {
             if (v != config.opt_start_seq) return configMismatch("opt_start_seq", v, config.opt_start_seq);
@@ -795,23 +809,23 @@ pub const JetStream = struct {
         if (requested.opt_start_time) |v| {
             if (!optStrEql(v, config.opt_start_time)) return configMismatchStr("opt_start_time", v, config.opt_start_time);
         }
-        if (requested.ack_policy != defaults.ack_policy and requested.ack_policy != config.ack_policy) {
-            return configMismatch("ack_policy", requested.ack_policy, config.ack_policy);
+        if (requested.ack_policy) |v| {
+            if (v != config.ack_policy) return configMismatch("ack_policy", v, config.ack_policy);
         }
-        if (requested.ack_wait != defaults.ack_wait and requested.ack_wait != config.ack_wait) {
-            return configMismatch("ack_wait", requested.ack_wait, config.ack_wait);
+        if (requested.ack_wait) |v| {
+            if (v != config.ack_wait) return configMismatch("ack_wait", v, config.ack_wait);
         }
-        if (requested.max_deliver != defaults.max_deliver and requested.max_deliver != config.max_deliver) {
-            return configMismatch("max_deliver", requested.max_deliver, config.max_deliver);
+        if (requested.max_deliver) |v| {
+            if (v != config.max_deliver) return configMismatch("max_deliver", v, config.max_deliver);
         }
-        if (requested.replay_policy != defaults.replay_policy and requested.replay_policy != config.replay_policy) {
-            return configMismatch("replay_policy", requested.replay_policy, config.replay_policy);
+        if (requested.replay_policy) |v| {
+            if (v != config.replay_policy) return configMismatch("replay_policy", v, config.replay_policy);
         }
         if (requested.rate_limit_bps) |v| {
             if (v != config.rate_limit_bps) return configMismatch("rate_limit_bps", v, config.rate_limit_bps);
         }
-        if (requested.max_ack_pending != defaults.max_ack_pending and requested.max_ack_pending != config.max_ack_pending) {
-            return configMismatch("max_ack_pending", requested.max_ack_pending, config.max_ack_pending);
+        if (requested.max_ack_pending) |v| {
+            if (v != config.max_ack_pending) return configMismatch("max_ack_pending", v, config.max_ack_pending);
         }
         if (requested.idle_heartbeat) |v| {
             if (v != config.idle_heartbeat) return configMismatch("idle_heartbeat", v, config.idle_heartbeat);
@@ -1481,9 +1495,10 @@ pub const JetStream = struct {
     /// byte limits, redeliveries, and control messages are independent of the
     /// number of unique unacknowledged messages.
     fn applyPendingLimits(subscription: *Subscription, consumer_config: *const ConsumerConfig) void {
-        if (consumer_config.max_ack_pending <= Subscription.default_pending_msgs_limit) return;
+        const configured = consumer_config.max_ack_pending orelse return;
+        if (configured <= Subscription.default_pending_msgs_limit) return;
 
-        const max_ack_pending: u64 = @intCast(consumer_config.max_ack_pending);
+        const max_ack_pending: u64 = @intCast(configured);
         const msgs_limit: u32 = std.math.cast(u32, max_ack_pending) orelse std.math.maxInt(u32);
         const bytes_limit = @max(max_ack_pending *| @as(u64, 1024 * 1024), Subscription.default_pending_bytes_limit);
         subscription.setPendingLimits(msgs_limit, bytes_limit);

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -342,3 +342,47 @@ test "JetStream subscribe rejects an existing consumer that does not match" {
         .config = .{ .ack_wait = 60 * std.time.ns_per_s },
     }));
 }
+
+test "JetStream consumer config leaves unset fields to the server" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+
+    var stream_info = try js.addStream(.{
+        .name = "TEST_DEFAULTS_STREAM",
+        .subjects = &.{"test.defaults.*"},
+        .max_msgs = 100,
+    });
+    defer stream_info.deinit();
+
+    // Subscribing without a config asks for explicit acks, because the server
+    // reads an omitted ack policy as 'none'. Everything else is the server's
+    // own default, sent back on the consumer info.
+    var sub = try js.subscribeSync("test.defaults.one", .{
+        .stream = "TEST_DEFAULTS_STREAM",
+        .durable = "defaults_consumer",
+    });
+    defer sub.deinit();
+
+    const config = sub.consumer_info.value.config;
+    try testing.expectEqual(.explicit, config.ack_policy);
+    try testing.expectEqual(.all, config.deliver_policy);
+    try testing.expectEqual(.instant, config.replay_policy);
+    try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), config.ack_wait.?);
+    try testing.expectEqual(@as(i64, 1000), config.max_ack_pending.?);
+    try testing.expectEqual(@as(i64, -1), config.max_deliver.?);
+
+    // addConsumer passes the config through as given, so an omitted ack policy
+    // reaches the server as one and comes back as 'none'.
+    var raw = try js.addConsumer("TEST_DEFAULTS_STREAM", .{
+        .name = "defaults_raw",
+        .durable_name = "defaults_raw",
+        .deliver_subject = "deliver.defaults",
+    });
+    defer raw.deinit();
+
+    try testing.expectEqual(.none, raw.value.config.ack_policy);
+}

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -262,3 +262,83 @@ test "JetStream subscribe attaches to an existing consumer named in the config" 
     try testing.expectEqualStrings("attached", js_msg.msg.data);
     try js_msg.ack();
 }
+
+test "JetStream subscribe rejects an existing consumer that does not match" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+
+    var stream_info = try js.addStream(.{
+        .name = "TEST_MISMATCH_STREAM",
+        .subjects = &.{"test.mismatch.*"},
+        .max_msgs = 100,
+    });
+    defer stream_info.deinit();
+
+    var push_consumer = try js.addConsumer("TEST_MISMATCH_STREAM", .{
+        .name = "mismatch_push",
+        .durable_name = "mismatch_push",
+        .deliver_subject = "deliver.mismatch",
+        .filter_subject = "test.mismatch.one",
+        .ack_wait = 60 * std.time.ns_per_s,
+    });
+    defer push_consumer.deinit();
+
+    var pull_consumer = try js.addConsumer("TEST_MISMATCH_STREAM", .{
+        .name = "mismatch_pull",
+        .durable_name = "mismatch_pull",
+        .filter_subject = "test.mismatch.one",
+    });
+    defer pull_consumer.deinit();
+
+    // A filter that does not cover the requested subject delivers nothing.
+    try testing.expectError(error.ConsumerConfigMismatch, js.subscribeSync("test.mismatch.two", .{
+        .stream = "TEST_MISMATCH_STREAM",
+        .durable = "mismatch_push",
+    }));
+
+    // Requesting an ack window the consumer does not have changes redelivery
+    // behaviour, silently, for every message.
+    try testing.expectError(error.ConsumerConfigMismatch, js.subscribeSync("test.mismatch.one", .{
+        .stream = "TEST_MISMATCH_STREAM",
+        .durable = "mismatch_push",
+        .config = .{ .ack_wait = 10 * std.time.ns_per_s },
+    }));
+
+    // A consumer with no deliver group does not serve a queue subscription.
+    try testing.expectError(error.ConsumerConfigMismatch, js.queueSubscribeSync("test.mismatch.one", "workers", .{
+        .stream = "TEST_MISMATCH_STREAM",
+        .durable = "mismatch_push",
+    }));
+
+    // Pull and push consumers are not interchangeable.
+    try testing.expectError(error.PushSubscribeToPullConsumer, js.subscribeSync("test.mismatch.one", .{
+        .stream = "TEST_MISMATCH_STREAM",
+        .durable = "mismatch_pull",
+    }));
+
+    try testing.expectError(error.PullSubscribeToPushConsumer, js.pullSubscribe("test.mismatch.one", "mismatch_push", .{
+        .stream = "TEST_MISMATCH_STREAM",
+    }));
+
+    // The matching request still attaches.
+    var sub = try js.subscribeSync("test.mismatch.one", .{
+        .stream = "TEST_MISMATCH_STREAM",
+        .durable = "mismatch_push",
+        .config = .{ .ack_wait = 60 * std.time.ns_per_s },
+    });
+    defer sub.deinit();
+
+    try testing.expectEqualStrings("deliver.mismatch", sub.consumer_info.value.config.deliver_subject.?);
+
+    // A second plain subscription would split the consumer's delivery with the
+    // first one, at random.
+    try testing.expectError(error.ConsumerAlreadyBound, js.subscribeSync("test.mismatch.one", .{
+        .stream = "TEST_MISMATCH_STREAM",
+        .durable = "mismatch_push",
+        .config = .{ .ack_wait = 60 * std.time.ns_per_s },
+    }));
+}

--- a/tests/jetstream_sync_test.zig
+++ b/tests/jetstream_sync_test.zig
@@ -214,3 +214,51 @@ test "JetStream pending limits remain bounded and track large ack windows" {
 
     try std.testing.expectEqual(nats.Subscription.default_pending_msgs_limit, default_sub.subscription.pending_msgs_limit.load(.acquire));
 }
+
+test "JetStream subscribe attaches to an existing consumer named in the config" {
+    const io = std.testing.io;
+
+    const conn = try utils.createDefaultConnection(io);
+    defer utils.closeConnection(conn);
+
+    var js = conn.jetstream(.{});
+
+    var stream_info = try js.addStream(.{
+        .name = "TEST_ATTACH_STREAM",
+        .subjects = &.{"test.attach.*"},
+        .max_msgs = 100,
+    });
+    defer stream_info.deinit();
+
+    // A consumer already delivering to a subject of its own choosing.
+    var existing = try js.addConsumer("TEST_ATTACH_STREAM", .{
+        .name = "attach_consumer",
+        .durable_name = "attach_consumer",
+        .deliver_subject = "test.attach.deliver.existing",
+        .filter_subject = "test.attach.*",
+        .ack_policy = .explicit,
+    });
+    defer existing.deinit();
+
+    // Subscribing by that name must attach to it and receive on its deliver
+    // subject, not create a second consumer or wait on the requested one.
+    var sub = try js.subscribeSync(null, .{
+        .stream = "TEST_ATTACH_STREAM",
+        .config = .{
+            .name = "attach_consumer",
+            .deliver_subject = "test.attach.deliver.requested",
+        },
+    });
+    defer sub.deinit();
+
+    try testing.expectEqualStrings("attach_consumer", sub.consumer_info.value.name);
+    try testing.expectEqualStrings("test.attach.deliver.existing", sub.consumer_info.value.config.deliver_subject.?);
+
+    try conn.publish("test.attach.message", "attached");
+
+    const js_msg = try sub.nextMsg();
+    defer js_msg.deinit();
+
+    try testing.expectEqualStrings("attached", js_msg.msg.data);
+    try js_msg.ack();
+}


### PR DESCRIPTION
Fixes #161, #160 and #165, in four commits meant to be read in order.

## 1. Register the delivery subscription before creating the consumer (#161)

Every push subscribe path created the server-side consumer first and subscribed to its deliver subject second. A subscription only queues a SUB frame for the next flush, so a delivery landing in that window has no interest and the server drops it.

`ack_policy = .explicit` consumers mostly self-heal through redelivery. The library's own internal consumers do not: KV watch/history/keys and Object Store get/list all use `ack_policy = .none`, so a message lost there is gone and those calls return short results with no error.

Subscribing first puts the SUB frame ahead of the create request on the same connection, so interest exists before the server can push anything. This is the order both official clients use — nats.go subscribes at `js.go:1934` and upserts at `:1959`, nats.c at `js.c:2991` and `:3009`, each after a consumer info lookup that resolves the deliver subject.

`pullSubscribe` is reordered the same way. It was not losing messages — nothing is delivered to a pull consumer until a fetch request is sent — but the wildcard inbox subscription has no reason to come second.

The subscribe errdefers change from `nc.unsubscribe(subscription)` to `subscription.deinit()`, which is #160. `nc.unsubscribe` drops only the connection's reference and leaves the caller's, so the subscription is never destroyed and `Connection.deinit()` panics about a live subscription the caller never received. That was previously reachable only through a failed wrapper allocation; with the create request now inside the same scope, a far more ordinary failure reaches it.

## 2. Attach to the consumer that wins a create race

Two clients subscribing to the same durable can both find nothing and both try to create it. The loser got "consumer already exists" handed back to it, even though the consumer it asked for now exists — and its subscription is pointing at the wrong deliver subject, since the winner's consumer has its own.

Look the winner up, drop the subscription, go round once more. Both official clients recover the same way (`js.go:1971-1990`, `js.c:3003-3027`). The retry can only run once, because the second pass has a consumer to attach to and returns before reaching `addConsumer`.

The four push paths move onto one `subscribeToPushConsumer` helper to get this, since the retry has to re-run the subscribe and each path performs a different one.

Consumers are now also looked up under the name the config carries, not only under the `durable` option, matching how both clients resolve the name they create under. Without it, naming a consumer through the config skipped the lookup and went straight to a create the server rejects.

## 3. Reject an existing consumer that does not match the request (#165)

Attaching to an existing consumer took it as-is and ignored the requested config, so a different filter subject, ack wait or deliver policy silently gave you the consumer's behaviour instead of yours.

Two cases were worse than silent. A push subscribe against a pull consumer read `deliver_subject` with `.?` on a null and panicked. And a second plain subscription to an already-bound push consumer is accepted by the server, which then splits that consumer's delivery between the two at random.

`checkExistingConsumer` mirrors `processConsInfo`/`checkConfig` in nats.go and `_processConsInfo` in nats.c: filter subject, pull versus push, deliver group versus queue group, `push_bound`, then the config fields. `push_bound` is new on `ConsumerInfo`; the server has always sent it.

One deliberate difference from nats.go: subscribing without a subject to a consumer that has a filter subject is allowed here. nats.go treats the empty subject as a mismatch, but binding to a durable by name alone is a normal way to use this API.

## 4. Let unset consumer config fields fall through to the server

Six `ConsumerConfig` fields were plain values holding the library's copy of the server's defaults, sent on every create whether or not the caller cared, with no way to express "not set". That made the check in commit 3 approximate — a value equal to the default had to be treated as unset — and meant a consumer could never inherit a default from a stream's `ConsumerLimits`, an account limit, or a future server release.

They are now optional and dropped from the request when null. Five produce exactly what the library used to send, because those values were the server's defaults already: `deliver_policy` all, `replay_policy` instant, `max_deliver` -1 (`consumer.go:611`), `ack_wait` 30s (`consumer.go:672`), `max_ack_pending` 1000 (`consumer.go:695`) — the last now behind the stream's consumer limits rather than in front of them.

`ack_policy` is the exception and keeps a client-side default: the server reads an omitted ack policy as `none`, which would turn every default subscription into one that never acknowledges. `buildConsumerConfig` asks for `explicit` when the caller did not choose, which is what nats.go does at `js.go:1877`. `addConsumer` still passes the config through untouched.

The mismatch check loses its special cases along with the defaults, so asking for a default value explicitly is now checked like any other request. Each field documents what the server does with it when it is not sent.

## Testing

`./check.sh` is green: 132 unit tests, 182 e2e.

New tests in `tests/jetstream_sync_test.zig` cover attaching to a consumer named in the config, six rejection cases (filter subject, ack wait, queue group, both binding directions, already-bound) with the matching request still attaching, and the defaulting behaviour of commit 4 including the deliberate difference between `subscribeSync` and `addConsumer`.

Two things have no test. The create race in commit 2 needs another client to create the consumer inside the window between our lookup and our create, which nothing in the suite can arrange deterministically. The delivery window in commit 1 is a race against the server with no client-side trigger.

## Unrelated, noticed while running the suite

`autounsubscribe_test.test.autounsubscribe async basic functionality` is flaky on `main`, panicking with `Connection.deinit() with 1 live subscription(s)` in 3 of 5 runs there. It does not touch JetStream and is unaffected by this branch, but it looks like a real refcount race in `autoUnsubscribe` rather than a test bug.