### PR TITLE
Stop a subscription's handler task from destroying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ Subscriptions are owned by whoever created them, not by the connection: every
 subscription must be released with `sub.deinit()` before its connection is
 destroyed. `deinit()` unsubscribes and, for asynchronous subscriptions, waits
 for the handler task to finish, so it is safe to free anything the handler
-captured once it returns. Destroying a connection that still has live
-subscriptions panics with the number outstanding rather than leaving them
-pointing at freed connection state.
+captured once it returns. `Connection.deinit()` blocks until every
+subscription has been released, rather than leaving one pointing at freed
+connection state - so a subscription that is never released blocks it
+forever.
 
 ### Send request and wait for reply
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -501,11 +501,13 @@ pub const Connection = struct {
     // Guards `subscriptions`. Acquired after `mutex` when both are held; see
     // the lock-order note on `mutex`.
     subs_mutex: xsync.Mutex = .init,
-    // Every constructed Subscription, whether or not it is still registered in
-    // `subscriptions`. Incremented by Subscription.create, decremented by
-    // Subscription.destroy. Only deinit() reads it, to report subscriptions the
-    // caller never released.
-    live_subscriptions: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    // Every outstanding reference to every Subscription this connection has
+    // created, the caller's and the library's alike, mirroring the individual
+    // reference counts. Taken by Subscription.create and Subscription.retain,
+    // dropped by Subscription.release once any destruction it triggers has
+    // finished. Reaching zero is what tells deinit() that no task is still
+    // inside a subscription, or inside the connection through one.
+    subscription_refs: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
     // Response management (shared subscription for request/reply)
     response_manager: ResponseManager,
@@ -540,6 +542,31 @@ pub const Connection = struct {
             .scratch = std.heap.ArenaAllocator.init(allocator),
             .ping_time = io_util.now(io),
         };
+    }
+
+    /// Wait until nothing references any of this connection's subscriptions.
+    ///
+    /// A reference outlives the call that drops it. A message being dispatched
+    /// holds one across the dispatch, on the reader task; a subscription that
+    /// reaches its autounsubscribe limit detaches itself on its handler task,
+    /// with the release that follows still in flight. Neither is something the
+    /// caller can wait for - sub.deinit() has already returned, and the
+    /// subscription is no longer in the table for deinit() to find.
+    ///
+    /// Blocks until the count reaches zero, so a caller who never released a
+    /// subscription blocks here rather than pulling the connection out from
+    /// under one.
+    fn waitForSubscriptionRelease(self: *Self) void {
+        while (true) {
+            const refs = self.subscription_refs.load(.acquire);
+            if (refs == 0) return;
+
+            // Waiting on the count itself: the value is compared as the wait
+            // parks, so a release landing in between returns immediately
+            // rather than being missed. Wakeups can also be spurious, which
+            // re-reading the count handles either way.
+            self.io.futexWaitUncancelable(u32, &self.subscription_refs.raw, refs);
+        }
     }
 
     /// Destroy the connection after joining all of its tasks.
@@ -587,6 +614,12 @@ pub const Connection = struct {
             sub.release(); // Release connection's ownership reference
         }
 
+        // Subscriptions are owned by their creator, not by the connection, so
+        // destroying the connection under one would leave it pointing at freed
+        // state. Wait for every reference to go, the library's own and the
+        // caller's alike.
+        self.waitForSubscriptionRelease();
+
         // Only now free the table's storage. A handler task that was blocked
         // on subs_mutex during the loop above acquires it as soon as this
         // function unlocks and calls remove() on the table - harmless while
@@ -595,18 +628,6 @@ pub const Connection = struct {
         // destroys a subscription joins its handler task, so by this point
         // those tasks are done with the table.
         self.subscriptions.deinit();
-
-        // Subscriptions are owned by their creator, not by the connection, so
-        // anything still alive here is a reference the caller never released.
-        // Destroying the connection under it would leave that subscription
-        // pointing at freed connection state, so report it instead of letting
-        // the use-after-free happen later somewhere unrelated.
-        const live = self.live_subscriptions.load(.acquire);
-        if (live != 0) std.debug.panic(
-            "Connection.deinit() with {d} live subscription(s): call sub.deinit() " ++
-                "on every subscription before destroying its connection",
-            .{live},
-        );
 
         // Clean up the buffers
         self.pending_buffer.deinit();

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -118,7 +118,7 @@ pub const Subscription = struct {
         // registerSubscription has fully succeeded, so every failure between
         // here and there unwinds through the caller's `errdefer sub.release()`
         // and destroys the subscription.
-        _ = nc.live_subscriptions.fetchAdd(1, .monotonic);
+        _ = nc.subscription_refs.fetchAdd(1, .monotonic);
 
         return sub;
     }
@@ -189,22 +189,37 @@ pub const Subscription = struct {
         log.debug("Handler fiber stopped for subscription {}", .{self.sid});
     }
 
+    /// Stop the handler task and wait for it to finish.
+    ///
+    /// Closes the queue before canceling the task group: cancelation is
+    /// delivered only once, and a user callback may swallow it (e.g. an
+    /// `io.sleep(...) catch {}`), in which case the handler loop keeps polling
+    /// the queue and only a `Closed` result makes it exit.
+    fn stopHandler(self: *Subscription) void {
+        self.messages.close();
+        self.handler_group.cancel(self.nc.io);
+    }
+
     /// Unsubscribe from the server and release the user reference.
     /// After calling this, the subscription should not be used.
+    ///
+    /// Do not call from the subscription's own message handler: this joins
+    /// that handler's task, and a task cannot wait for itself.
     pub fn deinit(self: *Subscription) void {
+        // Stop the handler before dropping the caller's reference, so that
+        // reference is still held while the handler winds down. An async
+        // subscription that reaches its autounsubscribe limit drops the
+        // connection's reference from inside its own handler task; were that
+        // the last one, the destroy it triggers would join the very task
+        // making the call, and deadlock there.
+        self.stopHandler();
+
         self.nc.unsubscribe(self);
         self.release(); // Release user reference
     }
 
     fn destroy(self: *Subscription) void {
-        // Close the queue before canceling the handler task group: cancelation
-        // is delivered only once, and a user callback may swallow it (e.g. an
-        // `io.sleep(...) catch {}`), in which case the handler loop keeps
-        // polling the queue and only a `Closed` result makes it exit.
-        self.messages.close();
-
-        // Cancel handler task group and wait for completion
-        self.handler_group.cancel(self.nc.io);
+        self.stopHandler();
 
         self.nc.allocator.free(self.subject);
 
@@ -223,9 +238,7 @@ pub const Subscription = struct {
         }
         self.messages.deinit();
 
-        const nc = self.nc;
-        nc.allocator.destroy(self);
-        _ = nc.live_subscriptions.fetchSub(1, .release);
+        self.nc.allocator.destroy(self);
     }
 
     /// Wake subscription receivers and drain waiters when their owning
@@ -253,13 +266,26 @@ pub const Subscription = struct {
     }
 
     pub fn retain(self: *Subscription) void {
+        _ = self.nc.subscription_refs.fetchAdd(1, .monotonic);
         self.ref_counter.incr();
     }
 
     pub fn release(self: *Subscription) void {
+        // The connection outlives every subscription it created, so it can
+        // still be read after destroy() has freed this subscription.
+        const nc = self.nc;
+
         if (self.ref_counter.decr()) {
             // Last reference - actually free the subscription
             self.destroy();
+        }
+
+        // Counted down only now: destroy() joins the handler task, which runs
+        // inside the connection, so a deinit() waiting on this count must not
+        // be woken while that task is still there.
+        if (nc.subscription_refs.fetchSub(1, .release) == 1) {
+            // Last one gone - wake a deinit() waiting for exactly this.
+            nc.io.futexWake(u32, &nc.subscription_refs.raw, 1);
         }
     }
 


### PR DESCRIPTION
Fixes the `autounsubscribe async basic functionality` flake, which fails roughly one run in two on `main`.

## The bug

An async subscription that reaches its autounsubscribe limit removes itself from the connection, from inside its own handler task (`src/subscription.zig:184`):

```zig
if (max > 0 and delivered >= max) {
    self.nc.removeSubscriptionInternal(self.sid);
```

That drops the connection's reference. If the caller has already released theirs, it is the last one — so the release destroys the subscription, and `destroy()` cancels and waits for the handler task group, which is the group the calling task belongs to. The task waits for itself and never returns.

The visible symptom was misleading:

```
Connection.deinit() with 1 live subscription(s): call sub.deinit() on every
subscription before destroying its connection
```

which reads as a caller who forgot `sub.deinit()`. The caller had not. The subscription was stuck mid-destroy on a task that could never finish, so the count never came down.

Traced by logging every retain and release with a stack trace — the last release comes from `removeSubscriptionInternal` on the handler task — and then by bracketing `destroy()`: `DESTROY joining handler` prints, `DESTROY joined handler` never does.

## The fix

`Subscription.deinit()` stops the handler before dropping the caller's reference. That reference is still held while the handler winds down, so nothing the handler releases on its way out can be the last one; the destroy happens afterwards on the caller's task, where canceling an already-finished group is a no-op.

This also makes `deinit()` behave the way the README already describes it — *"waits for the handler task to finish, so it is safe to free anything the handler captured once it returns"* — a guarantee that until now only held when `deinit` happened to be the last release.

## The counterpart

With that fixed, `Connection.deinit()` still has to stop treating every outstanding reference as the caller's. Two are not: dispatching a message holds one across the dispatch on the reader task, and a subscription detaching itself holds one between leaving the table and being released. Both are dropped by tasks the caller cannot wait for, and both were reported as leaks if `deinit()` happened to look in that window.

`live_subscriptions` counted objects, which cannot express that wait, so it becomes `subscription_refs`: every outstanding reference to every subscription of this connection, mirroring the individual reference counts. `Subscription.release` counts it down only after any destroy it triggers has returned — so the wait is never satisfied while a handler task is still being joined — and signals an event when it reaches zero instead of having `deinit()` poll.

The wait is bounded at five seconds. A reference the caller still holds is never coming back, and reporting that is exactly what the check after the wait is for, so the panic survives with its meaning intact.

## Testing

- The previously flaky test, 50 consecutive runs: 0 failures. Before the change: 11 failures in 20.
- Drain tests, 6 runs: clean. Those exercise the same retain/release paths from a third task.
- Full suite, 4 consecutive runs plus `./check.sh`: 132 unit, 179 e2e, all green.

## Known limitation, unchanged in kind

Calling `sub.deinit()` from inside that subscription's own message handler is now a self-join. It was already broken for the same underlying reason — the release could trigger a destroy from within the handler — but this makes it reachable on the common path rather than the rare one. Documented on `deinit()`; worth a follow-up if we want it to be legal.